### PR TITLE
feat(transport): add value codec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3880,7 +3880,7 @@ checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
 name = "wrpc"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -3947,7 +3947,7 @@ dependencies = [
 
 [[package]]
 name = "wrpc-transport"
-version = "0.25.1"
+version = "0.26.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3094,9 +3094,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-tokio"
-version = "0.5.5"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "715797300b1916d6c41369a0cbd62018a16f097b9aa23d1ed2d51b82e82dca19"
+checksum = "636f6a4dbe091857a76e50cd802b853a6b8c7a56f0c93a31c54769c032ee2af9"
 dependencies = [
  "leb128-tokio",
  "tokio",
@@ -3887,8 +3887,12 @@ dependencies = [
  "bytes",
  "clap",
  "futures",
+ "quinn",
+ "rcgen",
+ "rustls 0.23.10",
  "serde",
  "serde_json",
+ "test-log",
  "tokio",
  "tracing",
  "wit-bindgen-core",
@@ -3901,6 +3905,7 @@ dependencies = [
  "wrpc-transport-legacy",
  "wrpc-transport-nats",
  "wrpc-transport-nats-legacy",
+ "wrpc-transport-quic",
  "wrpc-wasmtime-nats-cli",
 ]
 
@@ -3944,11 +3949,13 @@ dependencies = [
 name = "wrpc-transport"
 version = "0.25.1"
 dependencies = [
+ "anyhow",
  "async-trait",
  "bytes",
  "futures",
  "test-log",
  "tokio",
+ "tokio-stream",
  "tokio-util",
  "tracing",
  "wasm-tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ repository = "https://github.com/wrpc/wrpc"
 members = ["crates/*", "examples/rust/*"]
 
 [features]
-default = ["bin", "nats", "wasmtime"]
+default = ["bin", "nats", "quic", "wasmtime"]
 
 bin = [
     "dep:clap",
@@ -43,6 +43,7 @@ nats = [
     "wrpc-cli/nats",
     "dep:wrpc-transport-nats-legacy", # TODO: Remove
 ]
+quic = ["dep:wrpc-transport-quic"]
 wasmtime = ["dep:wrpc-runtime-wasmtime"]
 
 [[bin]]
@@ -77,6 +78,7 @@ wrpc-cli = { workspace = true, optional = true }
 wrpc-runtime-wasmtime = { workspace = true, optional = true }
 wrpc-transport = { workspace = true }
 wrpc-transport-nats = { workspace = true, optional = true }
+wrpc-transport-quic = { workspace = true, optional = true }
 wrpc-wasmtime-nats-cli = { workspace = true, optional = true }
 
 # TODO: Remove
@@ -87,7 +89,17 @@ anyhow = { workspace = true }
 async-nats = { workspace = true }
 bytes = { workspace = true }
 futures = { workspace = true, features = ["async-await"] }
-tokio = { workspace = true, features = ["process"] }
+rcgen = { workspace = true, features = ["crypto", "ring", "zeroize"] }
+rustls = { workspace = true, features = ["logging", "ring"] }
+test-log = { workspace = true, features = ["color", "log", "trace"] }
+tokio = { workspace = true, features = ["process", "rt-multi-thread"] }
+quinn = { workspace = true, features = [
+    "log",
+    "platform-verifier",
+    "ring",
+    "runtime-tokio",
+    "rustls",
+] }
 wrpc-cli = { workspace = true }
 
 # TODO: Remove
@@ -122,7 +134,7 @@ tower = { version = "0.4", default-features = false }
 tracing = { version = "0.1", default-features = false }
 tracing-subscriber = { version = "0.3", default-features = false }
 url = { version = "2", default-features = false }
-wasm-tokio = { version = "0.5", default-features = false }
+wasm-tokio = { version = "0.5.7", default-features = false }
 wasmcloud-component-adapters = { version = "0.9", default-features = false }
 wasmparser = { version = "0.208", default-features = false }
 wasmtime = { version = "21", default-features = false }
@@ -141,6 +153,7 @@ wrpc-introspect = { version = "0.2", default-features = false, path = "./crates/
 wrpc-runtime-wasmtime = { version = "0.17", path = "./crates/runtime-wasmtime", default-features = false }
 wrpc-transport = { version = "0.25", path = "./crates/transport", default-features = false }
 wrpc-transport-nats = { version = "0.22", path = "./crates/transport-nats", default-features = false }
+wrpc-transport-quic = { version = "0.1", path = "./crates/transport-quic", default-features = false }
 wrpc-wasmtime-nats-cli = { version = "0.2", path = "./crates/wasmtime-nats-cli", default-features = false }
 
 # TODO: Remove

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wrpc"
-version = "0.2.0"
+version = "0.3.0"
 description = "WebAssembly component-native RPC framework based on WIT"
 
 authors.workspace = true
@@ -151,7 +151,7 @@ wit-parser = { version = "0.208", default-features = false }
 wrpc-cli = { version = "0.1", path = "./crates/cli", default-features = false }
 wrpc-introspect = { version = "0.2", default-features = false, path = "./crates/introspect" }
 wrpc-runtime-wasmtime = { version = "0.17", path = "./crates/runtime-wasmtime", default-features = false }
-wrpc-transport = { version = "0.25", path = "./crates/transport", default-features = false }
+wrpc-transport = { version = "0.26", path = "./crates/transport", default-features = false }
 wrpc-transport-nats = { version = "0.22", path = "./crates/transport-nats", default-features = false }
 wrpc-transport-quic = { version = "0.1", path = "./crates/transport-quic", default-features = false }
 wrpc-wasmtime-nats-cli = { version = "0.2", path = "./crates/wasmtime-nats-cli", default-features = false }

--- a/crates/transport/Cargo.toml
+++ b/crates/transport/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wrpc-transport"
-version = "0.25.1"
+version = "0.26.0"
 description = "wRPC core transport functionality"
 
 authors.workspace = true

--- a/crates/transport/Cargo.toml
+++ b/crates/transport/Cargo.toml
@@ -11,22 +11,18 @@ repository.workspace = true
 
 [features]
 default = ["frame"]
-frame = [
-    "dep:tokio-util",
-    "dep:tracing",
-    "dep:wasm-tokio",
-    "tokio-util/codec",
-    "tracing/attributes",
-]
+frame = []
 
 [dependencies]
+anyhow = { workspace = true, features = ["std"] }
 async-trait = { workspace = true }
 bytes = { workspace = true }
-futures = { workspace = true }
+futures = { workspace = true, features = ["std"] }
 tokio = { workspace = true }
-tokio-util = { workspace = true, optional = true }
-tracing = { workspace = true, optional = true }
-wasm-tokio = { workspace = true, optional = true }
+tokio-stream = { workspace = true }
+tokio-util = { workspace = true, features = ["codec"] }
+tracing = { workspace = true, features = ["attributes"] }
+wasm-tokio = { workspace = true }
 
 [dev-dependencies]
 test-log = { workspace = true, features = ["color", "log", "trace"] }

--- a/crates/transport/src/lib.rs
+++ b/crates/transport/src/lib.rs
@@ -1,38 +1,41 @@
-use core::fmt::Display;
-use core::future::Future;
-use core::str::FromStr;
+#![allow(clippy::type_complexity)]
 
-use bytes::Bytes;
-use futures::Stream;
+use core::future::Future;
+use core::pin::Pin;
+
+use std::sync::Arc;
+
+use anyhow::{bail, Context as _};
+use bytes::{Bytes, BytesMut};
+use futures::{SinkExt as _, Stream, TryStreamExt as _};
 use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::try_join;
+use tokio_util::codec::{Encoder as _, FramedRead, FramedWrite};
 
 #[cfg(feature = "frame")]
 pub mod frame;
 #[cfg(feature = "frame")]
 pub use frame::{Decoder as FrameDecoder, Encoder as FrameEncoder, FrameRef};
 
+mod value;
+pub use value::*;
+
 /// `Index` implementations are capable of multiplexing underlying connections using a particular
 /// structural `path`
 pub trait Index<T> {
-    /// Multiplexing error
-    type Error: Sync + Send;
-
     /// Index the entity using a structural `path`
-    fn index(&self, path: &[usize]) -> Result<T, Self::Error>;
+    fn index(&self, path: &[usize]) -> anyhow::Result<T>;
 }
 
 /// Invocation session, which is used to track the lifetime of the data exchange and for
 /// error reporting.
 pub trait Session {
-    type Error: FromStr + Display + Sync + Send;
-    type TransportError: Sync + Send;
-
     /// Finish the invocation session, closing all associated communication channels and reporting
     /// a result to the peer.
     fn finish(
         self,
-        res: Result<(), Self::Error>,
-    ) -> impl Future<Output = Result<Result<(), Self::Error>, Self::TransportError>> + Send;
+        res: Result<(), &str>,
+    ) -> impl Future<Output = anyhow::Result<Result<(), String>>> + Send + Sync;
 }
 
 /// Invocation encapsulates either server or client-side triple of:
@@ -51,21 +54,18 @@ pub struct Invocation<O, I, S> {
 }
 
 /// Client-side handle to a wRPC transport
-pub trait Invoke: Sync + Send {
-    /// Transport-specific error
-    type Error: Sync + Send;
-
+pub trait Invoke: Send + Sync {
     /// Transport-specific invocation context
-    type Context: Sync + Send;
+    type Context: Send + Sync;
 
     /// Transport-specific session used for lifetime tracking and error reporting
-    type Session: Session + Sync + Send;
+    type Session: Session + Send + Sync;
 
     /// Outgoing multiplexed byte stream
-    type Outgoing: AsyncWrite + Index<Self::Outgoing> + Sync + Send;
+    type Outgoing: AsyncWrite + Index<Self::Outgoing> + Send + Sync;
 
     /// Incoming multiplexed byte stream
-    type Incoming: AsyncRead + Index<Self::Incoming> + Sync + Send;
+    type Incoming: AsyncRead + Index<Self::Incoming> + Send + Sync;
 
     /// Invoke function `func` on instance `instance`
     fn invoke(
@@ -76,26 +76,100 @@ pub trait Invoke: Sync + Send {
         params: Bytes,
         paths: &[&[Option<usize>]],
     ) -> impl Future<
-        Output = Result<Invocation<Self::Outgoing, Self::Incoming, Self::Session>, Self::Error>,
+        Output = anyhow::Result<Invocation<Self::Outgoing, Self::Incoming, Self::Session>>,
     > + Send;
+
+    /// Invoke function `func` on instance `instance` using typed `Params` and `Returns`
+    fn invoke_values<Params, Returns>(
+        &self,
+        cx: Self::Context,
+        instance: &str,
+        func: &str,
+        params: Params,
+        paths: &[&[Option<usize>]],
+    ) -> impl Future<
+        Output = anyhow::Result<(
+            Returns,
+            impl Future<Output = anyhow::Result<Result<(), String>>>,
+        )>,
+    > + Send
+    where
+        Self::Outgoing: 'static,
+        Self::Incoming: Unpin,
+        ValueEncoder<Self::Outgoing>: tokio_util::codec::Encoder<Params>,
+        ValueDecoder<Self::Incoming, Returns>: tokio_util::codec::Decoder<Item = Returns>,
+        Params: Send,
+        Returns: Decode,
+        <ValueEncoder<Self::Outgoing> as tokio_util::codec::Encoder<Params>>::Error:
+            std::error::Error + Send + Sync + 'static,
+        <ValueDecoder<Self::Incoming, Returns> as tokio_util::codec::Decoder>::Error:
+            std::error::Error + Send + Sync + 'static,
+    {
+        async {
+            let mut buf = BytesMut::default();
+            let mut enc = ValueEncoder::<Self::Outgoing>::default();
+            enc.encode(params, &mut buf)
+                .context("failed to encode parameters")?;
+            let Invocation {
+                outgoing,
+                incoming,
+                session,
+            } = self
+                .invoke(cx, instance, func, buf.freeze(), paths)
+                .await
+                .context("failed to invoke function")?;
+            let tx = tokio::spawn(async {
+                enc.write_deferred(outgoing)
+                    .await
+                    .context("failed to write async values")
+            });
+            let mut dec = FramedRead::new(
+                incoming,
+                ValueDecoder::<Self::Incoming, Returns>::new(Vec::default()),
+            );
+            let Some(returns) = dec
+                .try_next()
+                .await
+                .context("failed to decode return values")?
+            else {
+                bail!("incomplete returns")
+            };
+            let rx = dec.decoder_mut().take_deferred();
+            Ok((returns, async {
+                if let Some(rx) = rx {
+                    try_join!(
+                        async {
+                            rx(dec.into_inner())
+                                .await
+                                .context("reading async return values failed")
+                        },
+                        async { tx.await.context("writing async parameters failed")? }
+                    )?;
+                } else {
+                    tx.await.context("writing async parameters failed")??;
+                };
+                session
+                    .finish(Ok(()))
+                    .await
+                    .context("failed to finish session")
+            }))
+        }
+    }
 }
 
 /// Server-side handle to a wRPC transport
 pub trait Serve {
-    /// Transport-specific error
-    type Error: Sync + Send;
-
     /// Transport-specific invocation context
-    type Context: Sync + Send;
+    type Context: Send + Sync;
 
     /// Transport-specific session used for lifetime tracking and error reporting
-    type Session: Session + Sync + Send;
+    type Session: Session + Send + Sync;
 
     /// Outgoing multiplexed byte stream
-    type Outgoing: AsyncWrite + Index<Self::Outgoing> + Sync + Send;
+    type Outgoing: AsyncWrite + Index<Self::Outgoing> + Send + Sync;
 
     /// Incoming multiplexed byte stream
-    type Incoming: AsyncRead + Index<Self::Incoming> + Sync + Send;
+    type Incoming: AsyncRead + Index<Self::Incoming> + Send + Sync;
 
     /// Serve function `func` from instance `instance`
     fn serve(
@@ -104,17 +178,113 @@ pub trait Serve {
         func: &str,
         paths: &[&[Option<usize>]],
     ) -> impl Future<
-        Output = Result<
+        Output = anyhow::Result<
             impl Stream<
-                Item = Result<
-                    (
-                        Self::Context,
-                        Invocation<Self::Outgoing, Self::Incoming, Self::Session>,
-                    ),
-                    Self::Error,
-                >,
+                Item = anyhow::Result<(
+                    Self::Context,
+                    Invocation<Self::Outgoing, Self::Incoming, Self::Session>,
+                )>,
             >,
-            Self::Error,
         >,
     > + Send;
+
+    /// Serve function `func` from instance `instance` using typed `Params` and `Returns`
+    fn serve_values<Params, Returns>(
+        &self,
+        instance: &str,
+        func: &str,
+        paths: &[&[Option<usize>]],
+    ) -> impl Future<
+        Output = anyhow::Result<
+            impl Stream<
+                Item = anyhow::Result<(
+                    Self::Context,
+                    Params,
+                    Option<impl Future<Output = std::io::Result<()>> + Sync + Send + Unpin>,
+                    impl FnOnce(
+                        Result<Returns, Arc<str>>,
+                    ) -> Pin<
+                        Box<dyn Future<Output = anyhow::Result<Result<(), String>>> + Sync + Send>,
+                    >,
+                )>,
+            >,
+        >,
+    > + Send
+    where
+        Self: Sync,
+        Self::Incoming: Unpin,
+        Self::Outgoing: Unpin + 'static,
+        Self::Session: 'static,
+        Params: Decode,
+        Returns: Send + Sync + 'static,
+        ValueEncoder<Self::Outgoing>: tokio_util::codec::Encoder<Returns>,
+        ValueDecoder<Self::Incoming, Params>: tokio_util::codec::Decoder<Item = Params>,
+        <ValueEncoder<Self::Outgoing> as tokio_util::codec::Encoder<Returns>>::Error:
+            std::error::Error + Send + Sync + 'static,
+        <ValueDecoder<Self::Incoming, Params> as tokio_util::codec::Decoder>::Error:
+            std::error::Error + Send + Sync + 'static,
+    {
+        async {
+            let invocations = self.serve(instance, func, paths).await?;
+            Ok(invocations.and_then(
+                |(
+                    cx,
+                    Invocation {
+                        outgoing,
+                        incoming,
+                        session,
+                    },
+                )| async {
+                    let mut dec = FramedRead::new(
+                        incoming,
+                        ValueDecoder::<Self::Incoming, Params>::new(Vec::default()),
+                    );
+                    let Some(params) = dec
+                        .try_next()
+                        .await
+                        .context("failed to decode parameters")?
+                    else {
+                        bail!("incomplete parameters")
+                    };
+                    let rx = dec.decoder_mut().take_deferred();
+                    Ok((
+                        cx,
+                        params,
+                        rx.map(|f| f(dec.into_inner())),
+                        |returns: Result<_, Arc<str>>| {
+                            Box::pin(async move {
+                                match returns {
+                                    Ok(returns) => {
+                                        let mut enc = FramedWrite::<
+                                            Self::Outgoing,
+                                            ValueEncoder<Self::Outgoing>,
+                                        >::new(
+                                            outgoing,
+                                            ValueEncoder::<Self::Outgoing>::default(),
+                                        );
+                                        enc.send(returns)
+                                            .await
+                                            .context("failed to write return values")?;
+                                        if let Some(tx) = enc.encoder_mut().take_deferred() {
+                                            tx(enc.into_inner())
+                                                .await
+                                                .context("failed to write async return values")?;
+                                        }
+                                        session
+                                            .finish(Ok(()))
+                                            .await
+                                            .context("failed to finish session")
+                                    }
+                                    Err(err) => session
+                                        .finish(Err(&err))
+                                        .await
+                                        .context("failed to finish session"),
+                                }
+                            }) as Pin<_>
+                        },
+                    ))
+                },
+            ))
+        }
+    }
 }

--- a/crates/transport/src/value.rs
+++ b/crates/transport/src/value.rs
@@ -1,0 +1,757 @@
+use core::future::Future;
+use core::iter::zip;
+use core::mem;
+use core::pin::Pin;
+
+use bytes::{Buf as _, BufMut as _, Bytes, BytesMut};
+use futures::stream::{self, FuturesUnordered};
+use futures::{Stream, StreamExt as _, TryStreamExt as _};
+use std::sync::Arc;
+use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt as _};
+use tokio::sync::mpsc;
+use tokio::try_join;
+use tokio_stream::wrappers::ReceiverStream;
+use tokio_util::codec::FramedRead;
+use tracing::instrument;
+use wasm_tokio::cm::{
+    BoolCodec, F32Codec, F64Codec, S16Codec, S32Codec, S64Codec, S8Codec, TupleDecoder, U16Codec,
+    U32Codec, U64Codec, U8Codec,
+};
+use wasm_tokio::{
+    CoreNameDecoder, CoreNameEncoder, CoreVecDecoderBytes, CoreVecEncoderBytes, Leb128DecoderU32,
+    Leb128Encoder, Utf8Codec,
+};
+
+pub struct ValueEncoder<W>(
+    Option<
+        Box<
+            dyn FnOnce(W) -> Pin<Box<dyn Future<Output = std::io::Result<()>> + Send + Sync>>
+                + Send
+                + Sync,
+        >,
+    >,
+);
+
+impl<W> Default for ValueEncoder<W> {
+    fn default() -> Self {
+        Self(None)
+    }
+}
+
+impl<W> ValueEncoder<W> {
+    pub fn set_deferred(
+        &mut self,
+        f: Box<
+            dyn FnOnce(W) -> Pin<Box<dyn Future<Output = std::io::Result<()>> + Send + Sync>>
+                + Send
+                + Sync,
+        >,
+    ) -> Option<
+        Box<
+            dyn FnOnce(W) -> Pin<Box<dyn Future<Output = std::io::Result<()>> + Send + Sync>>
+                + Send
+                + Sync,
+        >,
+    > {
+        self.0.replace(f)
+    }
+
+    pub fn take_deferred(
+        &mut self,
+    ) -> Option<
+        Box<
+            dyn FnOnce(W) -> Pin<Box<dyn Future<Output = std::io::Result<()>> + Send + Sync>>
+                + Send
+                + Sync,
+        >,
+    > {
+        self.0.take()
+    }
+
+    pub async fn write_deferred(self, w: W) -> std::io::Result<()> {
+        let Some(f) = self.0 else { return Ok(()) };
+        f(w).await
+    }
+}
+
+pub trait Decode: Send + Sync {
+    type State<R>: Default + Send + Sync;
+}
+
+pub struct ValueDecoder<R, T: Decode> {
+    state: T::State<R>,
+    index: Vec<usize>,
+    deferred: Option<
+        Box<
+            dyn FnOnce(R) -> Pin<Box<dyn Future<Output = std::io::Result<()>> + Send + Sync>>
+                + Send
+                + Sync,
+        >,
+    >,
+}
+
+impl<R, T: Decode> Default for ValueDecoder<R, T> {
+    fn default() -> Self {
+        Self {
+            state: T::State::<R>::default(),
+            index: Vec::default(),
+            deferred: None,
+        }
+    }
+}
+
+impl<R, T: Decode> ValueDecoder<R, T> {
+    #[must_use]
+    pub fn new(index: Vec<usize>) -> Self {
+        Self {
+            state: T::State::default(),
+            index,
+            deferred: None,
+        }
+    }
+
+    pub fn set_deferred(
+        &mut self,
+        f: Box<
+            dyn FnOnce(R) -> Pin<Box<dyn Future<Output = std::io::Result<()>> + Send + Sync>>
+                + Send
+                + Sync,
+        >,
+    ) -> Option<
+        Box<
+            dyn FnOnce(R) -> Pin<Box<dyn Future<Output = std::io::Result<()>> + Send + Sync>>
+                + Send
+                + Sync,
+        >,
+    > {
+        self.deferred.replace(f)
+    }
+
+    pub fn take_deferred(
+        &mut self,
+    ) -> Option<
+        Box<
+            dyn FnOnce(R) -> Pin<Box<dyn Future<Output = std::io::Result<()>> + Send + Sync>>
+                + Send
+                + Sync,
+        >,
+    > {
+        self.deferred.take()
+    }
+
+    pub async fn read_deferred(self, r: R) -> std::io::Result<()> {
+        let Some(f) = self.deferred else {
+            return Ok(());
+        };
+        f(r).await
+    }
+}
+
+macro_rules! impl_copy_codec {
+    ($t:ty, $c:expr) => {
+        impl<W> tokio_util::codec::Encoder<$t> for ValueEncoder<W> {
+            type Error = std::io::Error;
+
+            #[instrument(level = "trace", skip(self), ret)]
+            fn encode(&mut self, item: $t, dst: &mut BytesMut) -> std::io::Result<()> {
+                $c.encode(item, dst)
+            }
+        }
+
+        impl<W> tokio_util::codec::Encoder<&$t> for ValueEncoder<W> {
+            type Error = std::io::Error;
+
+            #[instrument(level = "trace", skip(self), ret)]
+            fn encode(&mut self, item: &$t, dst: &mut BytesMut) -> std::io::Result<()> {
+                $c.encode(*item, dst)
+            }
+        }
+
+        impl<R> tokio_util::codec::Decoder for ValueDecoder<R, $t> {
+            type Item = $t;
+            type Error = std::io::Error;
+
+            #[instrument(level = "trace", skip(self), ret)]
+            fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+                $c.decode(src)
+            }
+        }
+
+        impl Decode for $t {
+            type State<R> = ();
+        }
+    };
+}
+
+impl_copy_codec!(bool, BoolCodec);
+impl_copy_codec!(i8, S8Codec);
+impl_copy_codec!(u8, U8Codec);
+impl_copy_codec!(i16, S16Codec);
+impl_copy_codec!(u16, U16Codec);
+impl_copy_codec!(i32, S32Codec);
+impl_copy_codec!(u32, U32Codec);
+impl_copy_codec!(i64, S64Codec);
+impl_copy_codec!(u64, U64Codec);
+impl_copy_codec!(f32, F32Codec);
+impl_copy_codec!(f64, F64Codec);
+impl_copy_codec!(char, Utf8Codec);
+
+macro_rules! impl_string_encode {
+    ($t:ty) => {
+        impl<W> tokio_util::codec::Encoder<$t> for ValueEncoder<W> {
+            type Error = std::io::Error;
+
+            #[instrument(level = "trace", skip(self), ret)]
+            fn encode(&mut self, item: $t, dst: &mut BytesMut) -> std::io::Result<()> {
+                CoreNameEncoder.encode(item, dst)
+            }
+        }
+
+        impl<W> tokio_util::codec::Encoder<&$t> for ValueEncoder<W> {
+            type Error = std::io::Error;
+
+            #[instrument(level = "trace", skip(self), ret)]
+            fn encode(&mut self, item: &$t, dst: &mut BytesMut) -> std::io::Result<()> {
+                CoreNameEncoder.encode(item, dst)
+            }
+        }
+    };
+}
+
+impl_string_encode!(&str);
+impl_string_encode!(String);
+
+impl<R> tokio_util::codec::Decoder for ValueDecoder<R, String> {
+    type Item = String;
+    type Error = std::io::Error;
+
+    #[instrument(level = "trace", skip(self), ret)]
+    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+        self.state.decode(src)
+    }
+}
+
+impl Decode for String {
+    type State<R> = CoreNameDecoder;
+}
+
+impl<W> tokio_util::codec::Encoder<Bytes> for ValueEncoder<W> {
+    type Error = std::io::Error;
+
+    #[instrument(level = "trace", skip(self), ret)]
+    fn encode(&mut self, item: Bytes, dst: &mut BytesMut) -> std::io::Result<()> {
+        CoreVecEncoderBytes.encode(item, dst)
+    }
+}
+
+impl<W> tokio_util::codec::Encoder<&Bytes> for ValueEncoder<W> {
+    type Error = std::io::Error;
+
+    #[instrument(level = "trace", skip(self), ret)]
+    fn encode(&mut self, item: &Bytes, dst: &mut BytesMut) -> std::io::Result<()> {
+        CoreVecEncoderBytes.encode(item.as_ref(), dst)
+    }
+}
+
+impl<R> tokio_util::codec::Decoder for ValueDecoder<R, Bytes> {
+    type Item = Bytes;
+    type Error = std::io::Error;
+
+    #[instrument(level = "trace", skip(self), ret)]
+    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+        self.state.decode(src)
+    }
+}
+
+impl Decode for Bytes {
+    type State<R> = CoreVecDecoderBytes;
+}
+
+async fn handle_deferred<T, I>(w: T, deferred: I) -> std::io::Result<()>
+where
+    T: crate::Index<T> + 'static,
+    I: IntoIterator,
+    I::IntoIter: ExactSizeIterator<
+        Item = Option<
+            Box<
+                dyn FnOnce(T) -> Pin<Box<dyn Future<Output = std::io::Result<()>> + Send + Sync>>
+                    + Send
+                    + Sync,
+            >,
+        >,
+    >,
+{
+    let futs: FuturesUnordered<_> = zip(0.., deferred)
+        .filter_map(|(i, f)| f.map(|f| (w.index(&[i]), f)))
+        .map(|(w, f)| async move {
+            let w = w.map_err(std::io::Error::other)?;
+            f(w).await
+        })
+        .collect();
+    futs.try_collect().await?;
+    Ok(())
+}
+
+macro_rules! impl_tuple_codec {
+    ($($vn:ident),+; $($vt:ident),+; $($cn:ident),+) => {
+        impl<E, W, $($vt),+> tokio_util::codec::Encoder<($($vt),+,)> for ValueEncoder<W>
+        where
+            E: From<std::io::Error>,
+            W: AsyncWrite + crate::Index<W> + Send + Sync + 'static,
+            std::io::Error: From<E>,
+            $(Self: tokio_util::codec::Encoder<$vt, Error = E>),+
+        {
+            type Error = std::io::Error;
+
+            #[instrument(level = "trace", skip_all, ret, fields(ty = "tuple", dst))]
+            fn encode(&mut self, ($($vn),+,): ($($vt),+,), dst: &mut BytesMut) -> std::io::Result<()> {
+                $(
+                    let mut $cn = Self::default();
+                    $cn.encode($vn, dst)?;
+                )+
+                let deferred = [ $($cn.take_deferred()),+ ];
+                if deferred.iter().any(Option::is_some) {
+                    self.0 = Some(Box::new(|w| Box::pin(handle_deferred(w, deferred))));
+                }
+                Ok(())
+            }
+        }
+
+        impl<E, R, $($vt),+> tokio_util::codec::Decoder for ValueDecoder<R, ($($vt),+,)>
+        where
+            E: From<std::io::Error>,
+            R: AsyncRead + crate::Index<R> + Send + Sync + Unpin + 'static,
+            std::io::Error: From<E>,
+            $(ValueDecoder<R, $vt>: tokio_util::codec::Decoder<Item = $vt, Error = E>),+,
+            $($vt: Decode),+
+        {
+            type Error = std::io::Error;
+            type Item = ($($vt),+,);
+
+            #[instrument(level = "trace", skip(self))]
+            fn decode(
+                &mut self,
+                src: &mut BytesMut,
+            ) -> Result<Option<Self::Item>, Self::Error> {
+                let Some(ret) = self.state.decode(src)? else {
+                    return Ok(None)
+                };
+                let ($(mut $cn),+,) = mem::take(&mut self.state).into_inner();
+                let deferred = [ $($cn.take_deferred()),+ ];
+                if deferred.iter().any(Option::is_some) {
+                    self.deferred = Some(Box::new(|r| Box::pin(handle_deferred(r, deferred))));
+                }
+                Ok(Some(ret))
+            }
+        }
+
+        impl<$($vt),+> Decode for ($($vt),+,) where
+            $($vt: Decode),+
+        {
+            type State<R> = TupleDecoder::<($(ValueDecoder<R, $vt>),+,), ($(Option<$vt>),+,)>;
+        }
+    };
+}
+
+impl_tuple_codec!(
+    v0;
+    V0;
+    c0
+);
+
+impl_tuple_codec!(
+    v0, v1;
+    V0, V1;
+    c0, c1
+);
+
+impl_tuple_codec!(
+    v0, v1, v2;
+    V0, V1, V2;
+    c0, c1, c2
+);
+
+impl_tuple_codec!(
+    v0, v1, v2, v3;
+    V0, V1, V2, V3;
+    c0, c1, c2, c3
+);
+
+impl_tuple_codec!(
+    v0, v1, v2, v3, v4;
+    V0, V1, V2, V3, V4;
+    c0, c1, c2, c3, c4
+);
+
+impl_tuple_codec!(
+    v0, v1, v2, v3, v4, v5;
+    V0, V1, V2, V3, V4, V5;
+    c0, c1, c2, c3, c4, c5
+);
+
+impl_tuple_codec!(
+    v0, v1, v2, v3, v4, v5, v6;
+    V0, V1, V2, V3, V4, V5, V6;
+    c0, c1, c2, c3, c4, c5, c6
+);
+
+impl_tuple_codec!(
+    v0, v1, v2, v3, v4, v5, v6, v7;
+    V0, V1, V2, V3, V4, V5, V6, V7;
+    c0, c1, c2, c3, c4, c5, c6, c7
+);
+
+impl_tuple_codec!(
+    v0, v1, v2, v3, v4, v5, v6, v7, v8;
+    V0, V1, V2, V3, V4, V5, V6, V7, V8;
+    c0, c1, c2, c3, c4, c5, c6, c7, c8
+);
+
+impl_tuple_codec!(
+    v0, v1, v2, v3, v4, v5, v6, v7, v8, v9;
+    V0, V1, V2, V3, V4, V5, V6, V7, V8, V9;
+    c0, c1, c2, c3, c4, c5, c6, c7, c8, c9
+);
+
+impl_tuple_codec!(
+    v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10;
+    V0, V1, V2, V3, V4, V5, V6, V7, V8, V9, V10;
+    c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10
+);
+
+impl_tuple_codec!(
+    v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11;
+    V0, V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11;
+    c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11
+);
+
+impl<T, W> tokio_util::codec::Encoder<Vec<T>> for ValueEncoder<W>
+where
+    Self: tokio_util::codec::Encoder<T>,
+    W: AsyncWrite + crate::Index<W> + Send + Sync + 'static,
+    <Self as tokio_util::codec::Encoder<T>>::Error: Into<std::io::Error>,
+{
+    type Error = std::io::Error;
+
+    #[instrument(level = "trace", skip(self, item), fields(ty = "list"))]
+    fn encode(&mut self, item: Vec<T>, dst: &mut BytesMut) -> std::io::Result<()> {
+        let items = item.len();
+        let n = u32::try_from(items)
+            .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidInput, err))?;
+        dst.reserve(5 + items);
+        Leb128Encoder.encode(n, dst)?;
+        let mut deferred = Vec::with_capacity(items);
+        for item in item {
+            let mut enc = ValueEncoder::default();
+            enc.encode(item, dst).map_err(Into::into)?;
+            deferred.push(enc.0);
+        }
+        if deferred.iter().any(Option::is_some) {
+            self.0 = Some(Box::new(|w| Box::pin(handle_deferred(w, deferred))));
+        }
+        Ok(())
+    }
+}
+
+impl<T: Copy, W> tokio_util::codec::Encoder<&[T]> for ValueEncoder<W>
+where
+    Self: tokio_util::codec::Encoder<T, Error = std::io::Error>,
+    W: AsyncWrite + crate::Index<W> + Send + Sync + 'static,
+{
+    type Error = std::io::Error;
+
+    #[instrument(level = "trace", skip(self, item), fields(ty = "list"))]
+    fn encode(&mut self, item: &[T], dst: &mut BytesMut) -> std::io::Result<()> {
+        let items = item.len();
+        let n = u32::try_from(items)
+            .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidInput, err))?;
+        dst.reserve(5 + items);
+        Leb128Encoder.encode(n, dst)?;
+        let mut deferred = Vec::with_capacity(items);
+        for item in item {
+            let mut enc = ValueEncoder::default();
+            enc.encode(*item, dst)?;
+            deferred.push(enc.0);
+        }
+        if deferred.iter().any(Option::is_some) {
+            self.0 = Some(Box::new(|w| Box::pin(handle_deferred(w, deferred))));
+        }
+        Ok(())
+    }
+}
+
+impl<T, W> tokio_util::codec::Encoder<Pin<Box<dyn Future<Output = T> + Send + Sync>>>
+    for ValueEncoder<W>
+where
+    Self: tokio_util::codec::Encoder<T>,
+    W: AsyncWrite + crate::Index<W> + Send + Sync + Unpin + 'static,
+    T: 'static,
+    std::io::Error: From<<Self as tokio_util::codec::Encoder<T>>::Error>,
+{
+    type Error = std::io::Error;
+
+    #[instrument(level = "trace", skip(self, item), fields(ty = "future"))]
+    fn encode(
+        &mut self,
+        item: Pin<Box<dyn Future<Output = T> + Send + Sync>>,
+        dst: &mut BytesMut,
+    ) -> std::io::Result<()> {
+        dst.reserve(1);
+        dst.put_u8(0x00);
+        self.0 = Some(Box::new(|w| {
+            Box::pin(async move {
+                let mut w = w.index(&[0]).map_err(std::io::Error::other)?;
+                let item = item.await;
+                let mut enc = ValueEncoder::default();
+                let mut buf = BytesMut::default();
+                enc.encode(item, &mut buf)?;
+                w.write_all(&buf).await?;
+                enc.write_deferred(w).await?;
+                Ok(())
+            })
+        }));
+        Ok(())
+    }
+}
+
+impl<T, W> tokio_util::codec::Encoder<Pin<Box<dyn Stream<Item = T> + Send + Sync>>>
+    for ValueEncoder<W>
+where
+    Self: tokio_util::codec::Encoder<T>,
+    W: AsyncWrite + crate::Index<W> + Send + Sync + Unpin + 'static,
+    T: Send + Sync + 'static,
+    std::io::Error: From<<Self as tokio_util::codec::Encoder<T>>::Error>,
+{
+    type Error = std::io::Error;
+
+    #[instrument(level = "trace", skip(self, item), fields(ty = "stream"))]
+    fn encode(
+        &mut self,
+        item: Pin<Box<dyn Stream<Item = T> + Send + Sync>>,
+        dst: &mut BytesMut,
+    ) -> std::io::Result<()> {
+        dst.reserve(1);
+        dst.put_u8(0x00);
+        self.0 = Some(Box::new(|w| {
+            let w = Arc::new(w);
+            Box::pin(
+                item.enumerate()
+                    .map(Ok)
+                    .try_for_each_concurrent(None, move |(i, item)| {
+                        let w = Arc::clone(&w);
+                        async move {
+                            let mut w = w.index(&[i]).map_err(std::io::Error::other)?;
+                            let mut enc = ValueEncoder::<W>::default();
+                            let mut buf = BytesMut::default();
+                            enc.encode(item, &mut buf)?;
+                            w.write_all(&buf).await?;
+                            enc.write_deferred(w).await?;
+                            Ok(())
+                        }
+                    }),
+            )
+        }));
+        Ok(())
+    }
+}
+
+impl<T: Decode> Decode for Pin<Box<dyn Stream<Item = T> + Send + Sync>> {
+    type State<R> = Option<StreamChunkDecodeState<T>>;
+}
+
+impl<T: Decode> Decode for StreamChunk<T> {
+    type State<R> = StreamChunkDecodeState<T>;
+}
+
+struct StreamChunk<T>(Vec<T>);
+
+impl<T> Default for StreamChunk<T> {
+    fn default() -> Self {
+        Self(Vec::default())
+    }
+}
+
+pub struct StreamChunkDecodeState<T> {
+    offset: Option<usize>,
+    ret: Vec<T>,
+    cap: usize,
+}
+
+impl<T> Default for StreamChunkDecodeState<T> {
+    fn default() -> Self {
+        Self {
+            offset: None,
+            ret: Vec::default(),
+            cap: 0,
+        }
+    }
+}
+
+impl<R, T> tokio_util::codec::Decoder for ValueDecoder<R, StreamChunk<T>>
+where
+    ValueDecoder<R, T>: tokio_util::codec::Decoder<Item = T>,
+    R: AsyncRead + crate::Index<R> + Send + Sync + Unpin + 'static,
+    T: Decode,
+    std::io::Error: From<<ValueDecoder<R, T> as tokio_util::codec::Decoder>::Error>,
+{
+    type Item = StreamChunk<T>;
+    type Error = std::io::Error;
+
+    #[instrument(level = "trace", skip(self), fields(ty = "stream"))]
+    fn decode(&mut self, src: &mut BytesMut) -> std::io::Result<Option<Self::Item>> {
+        if self.state.cap == 0 {
+            let Some(len) = Leb128DecoderU32.decode(src)? else {
+                return Ok(None);
+            };
+            if len == 0 {
+                mem::take(&mut self.state);
+                return Ok(Some(StreamChunk::default()));
+            }
+            let len = len
+                .try_into()
+                .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidInput, err))?;
+            self.state.ret = Vec::with_capacity(len);
+            self.state.cap = len;
+        }
+        while self.state.cap > 0 {
+            let mut index = mem::take(&mut self.index);
+            let offset = self.state.offset.ok_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "stream element offset overflows usize",
+                )
+            })?;
+            let i = self.state.ret.len().checked_add(offset).ok_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "stream element index overflows usize",
+                )
+            })?;
+            index.push(i);
+            let mut dec = ValueDecoder::<R, T>::new(index);
+            let res = dec.decode(src);
+            let mut index = dec.index;
+            let Some(v) = res? else {
+                index.pop();
+                self.index = index;
+                return Ok(None);
+            };
+            if let Some(deferred) = dec.deferred {
+                let index = Arc::from(index.as_ref());
+                if let Some(f) = self.deferred.take() {
+                    self.deferred = Some(Box::new(|r| {
+                        Box::pin(async move {
+                            let indexed = r.index(&index).map_err(std::io::Error::other)?;
+                            try_join!(f(r), deferred(indexed))?;
+                            Ok(())
+                        })
+                    }));
+                } else {
+                    self.deferred = Some(Box::new(|r| {
+                        Box::pin(async move {
+                            let indexed = r.index(&index).map_err(std::io::Error::other)?;
+                            deferred(indexed).await
+                        })
+                    }));
+                }
+            }
+            index.pop();
+            self.index = index;
+            self.state.ret.push(v);
+            self.state.cap -= 1;
+            self.state.offset = offset.checked_add(1);
+        }
+        let StreamChunkDecodeState { ret, .. } = mem::take(&mut self.state);
+        Ok(Some(StreamChunk(ret)))
+    }
+}
+
+impl<R, T> tokio_util::codec::Decoder
+    for ValueDecoder<R, Pin<Box<dyn Stream<Item = T> + Send + Sync>>>
+where
+    ValueDecoder<R, T>: tokio_util::codec::Decoder<Item = T>,
+    R: AsyncRead + crate::Index<R> + Send + Sync + Unpin + 'static,
+    T: Decode + Send + Sync + 'static,
+    std::io::Error: From<<ValueDecoder<R, T> as tokio_util::codec::Decoder>::Error>,
+{
+    type Item = Pin<Box<dyn Stream<Item = T> + Send + Sync>>;
+    type Error = std::io::Error;
+
+    #[instrument(level = "trace", skip(self), fields(ty = "stream"))]
+    fn decode(&mut self, src: &mut BytesMut) -> std::io::Result<Option<Self::Item>> {
+        let state = if let Some(state) = self.state.take() {
+            state
+        } else {
+            if src.is_empty() {
+                src.reserve(1);
+                return Ok(None);
+            }
+            match src.get_u8() {
+                0 => {
+                    let index = self.index.clone();
+                    let (tx, rx) = mpsc::channel(128);
+                    self.deferred = Some(Box::new(|r| {
+                        Box::pin(async move {
+                            let indexed = r.index(&index).map_err(std::io::Error::other)?;
+                            let mut r = FramedRead::new(
+                                indexed,
+                                ValueDecoder::<R, StreamChunk<T>>::new(index),
+                            );
+                            while let Some(StreamChunk(chunk)) = r.try_next().await? {
+                                if chunk.is_empty() {
+                                    return Ok(());
+                                }
+                                for v in chunk {
+                                    tx.send(v).await.map_err(|_| {
+                                        std::io::Error::new(
+                                            std::io::ErrorKind::BrokenPipe,
+                                            "receiver closed",
+                                        )
+                                    })?;
+                                }
+                            }
+                            Ok(())
+                        })
+                    }));
+                    return Ok(Some(Box::pin(ReceiverStream::new(rx))));
+                }
+                1 => StreamChunkDecodeState::default(),
+                n => {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        format!("invalid stream status byte `{n}`"),
+                    ))
+                }
+            }
+        };
+        let index = mem::take(&mut self.index);
+        let mut dec = ValueDecoder::<R, StreamChunk<T>> {
+            state,
+            index,
+            deferred: None,
+        };
+        let res = dec.decode(src)?;
+        self.index = dec.index;
+        if let Some(StreamChunk(chunk)) = res {
+            Ok(Some(Box::pin(stream::iter(chunk))))
+        } else {
+            self.state = Some(dec.state);
+            Ok(None)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio_util::codec::Encoder as _;
+
+    use super::*;
+
+    #[test_log::test(tokio::test)]
+    async fn value_encoder() -> std::io::Result<()> {
+        let mut buf = BytesMut::new();
+        ValueEncoder::<()>::default().encode(0x42u8, &mut buf)?;
+        assert_eq!(buf.as_ref(), b"\x42");
+        Ok(())
+    }
+}

--- a/crates/wasmtime-nats-cli/src/lib.rs
+++ b/crates/wasmtime-nats-cli/src/lib.rs
@@ -32,19 +32,19 @@ pub enum Workload {
     Binary(Vec<u8>),
 }
 
-pub struct Ctx<C: Invoke<Error = wasmtime::Error>> {
+pub struct Ctx<C: Invoke> {
     pub table: ResourceTable,
     pub wasi: WasiCtx,
     pub wrpc: C,
 }
 
-impl<C: Invoke<Error = wasmtime::Error>> WrpcView<C> for Ctx<C> {
+impl<C: Invoke> WrpcView<C> for Ctx<C> {
     fn client(&self) -> &C {
         &self.wrpc
     }
 }
 
-impl<C: Invoke<Error = wasmtime::Error>> WasiView for Ctx<C> {
+impl<C: Invoke> WasiView for Ctx<C> {
     fn ctx(&mut self) -> &mut WasiCtx {
         &mut self.wasi
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,11 @@
 pub mod transport {
     pub use wrpc_transport::*;
+
     #[cfg(feature = "nats")]
     pub use wrpc_transport_nats as nats;
+
+    #[cfg(feature = "quic")]
+    pub use wrpc_transport_quic as quic;
 }
 
 pub mod runtime {

--- a/tests/go.rs
+++ b/tests/go.rs
@@ -5,14 +5,12 @@ use tokio::process::Command;
 use tokio::{fs, time::sleep};
 
 mod common;
-use common::{init, with_nats};
+use common::with_nats;
 use tracing::{info, instrument};
 
 #[instrument(ret)]
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn go_bindgen() -> anyhow::Result<()> {
-    init().await;
-
     if let Err(err) = fs::remove_dir_all("tests/go/bindings").await {
         match err.kind() {
             std::io::ErrorKind::NotFound => {}
@@ -211,10 +209,9 @@ async fn go_bindgen() -> anyhow::Result<()> {
     .await
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[instrument(ret)]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn go() -> anyhow::Result<()> {
-    init().await;
-
     let status = Command::new("go")
         .current_dir("go")
         .args(["test", "-v", "./..."])


### PR DESCRIPTION
- Remove associated `Error` types, and use `anyhow::Error` in `wrpc_transport` traits to simplify downstream usage. I really wish there was a nicer way to handle this and `std::io::Error` is a real pain to use in this context
- Add `ValueEncoder` and `ValueDecoder` drafts, the implementations will have to be expanded, but the idea is that users of `wrpc_transport` will implement `Encoder` and `Decoder` on these structs