### PR TITLE
fix(transport): rework trait bounds

### DIFF
--- a/crates/runtime-wasmtime/src/lib.rs
+++ b/crates/runtime-wasmtime/src/lib.rs
@@ -940,7 +940,7 @@ pub fn polyfill<'a, T, C, V>(
                         let Invocation { outgoing, incoming, session } = store
                             .data()
                             .client()
-                            .invoke(cx, &instance_name, &rpc_name, buf.freeze(), &[])
+                            .invoke(cx, &instance_name, &rpc_name, buf.freeze(), &[[]; 0])
                             .await
                             .with_context(|| {
                                 format!("failed to invoke `{instance_name}.{func_name}` polyfill via wRPC")

--- a/crates/transport-quic/tests/loopback.rs
+++ b/crates/transport-quic/tests/loopback.rs
@@ -66,7 +66,7 @@ async fn loopback() -> anyhow::Result<()> {
     let clt = Client::new(clt_ep, (Ipv4Addr::LOCALHOST, srv_addr.port()));
     let srv = Server::default();
     let invocations = srv
-        .serve("foo", "bar", &[&[Some(42), Some(0)]])
+        .serve("foo", "bar", [[Some(42), Some(0)]])
         .await
         .context("failed to serve `foo.bar`")?;
     let mut invocations = pin!(invocations);

--- a/tests/rust.rs
+++ b/tests/rust.rs
@@ -436,13 +436,13 @@ async fn rust_dynamic() -> anyhow::Result<()> {
         let srv = wrpc_transport_quic::Server::default();
 
         let foo_bar_inv = srv
-            .serve_values::<(
+            .serve_values::<[_; 0], (
                 (bool, u8, u16, u32, u64, i8, i16, i32, i64, f32, f64, char),
                 String,
             ), (
                 (bool, u8, u16, u32, u64, i8, i16, i32, i64, f32, f64, char),
                 &str,
-            )>("foo", "bar", &[])
+            )>("foo", "bar", [])
             .await
             .context("failed to serve `foo.bar`")?;
         let mut foo_bar_inv = pin!(foo_bar_inv);
@@ -522,7 +522,7 @@ async fn rust_dynamic() -> anyhow::Result<()> {
                             ),
                             "test",
                         ),
-                        &[],
+                        &[[]; 0],
                     )
                     .await
                     .expect("failed to invoke `foo.bar`");


### PR DESCRIPTION
Unfortunately, plain `&[&[Option<usize>]]` path bounds do not accept `Arc<[Arc<[Option<usize>]>]>` values, which users would likely use, especially in dynamic use cases. On top of that, lack of `'static` lifetime on the stream returned by `serve` prevents it from being passed into e.g. `tokio::spawn`.
Rework trait bounds to address these issues.

Thanks @luk3ark for reporting!