### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,9 +124,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
 
 [[package]]
-name = "async-nats"
+name = "async-nats-wrpc"
 version = "0.35.1"
-source = "git+https://github.com/rvolosatovs/nats.rs?branch=feat/command-sender#5354f827071197d9771ab4ce8083237ad526bd5a"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b90420a99c2fa8e337a0420f4fd684ac464b5a5d3c42fbbccc6261d7ed25bcc"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -1021,7 +1022,7 @@ name = "hello-nats-client"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-nats",
+ "async-nats-wrpc",
  "clap",
  "tokio",
  "tracing-subscriber",
@@ -1035,7 +1036,7 @@ name = "hello-nats-server"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-nats",
+ "async-nats-wrpc",
  "clap",
  "tokio",
  "tracing-subscriber",
@@ -3683,7 +3684,7 @@ name = "wrpc"
 version = "0.2.0"
 dependencies = [
  "anyhow",
- "async-nats",
+ "async-nats-wrpc",
  "bytes",
  "clap",
  "futures",
@@ -3712,7 +3713,7 @@ name = "wrpc-cli"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-nats",
+ "async-nats-wrpc",
  "tokio",
  "tracing-subscriber",
 ]
@@ -3764,7 +3765,7 @@ name = "wrpc-transport-nats"
 version = "0.22.0"
 dependencies = [
  "anyhow",
- "async-nats",
+ "async-nats-wrpc",
  "bytes",
  "futures",
  "tokio",
@@ -3799,7 +3800,7 @@ name = "wrpc-wasmtime-nats-cli"
 version = "0.2.0"
 dependencies = [
  "anyhow",
- "async-nats",
+ "async-nats-wrpc",
  "clap",
  "futures",
  "reqwest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2922,15 +2922,6 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.208.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd921789c9dcc495f589cb37d200155dee65b4a4beeb853323b5e24e0a5f9c58"
-dependencies = [
- "bitflags 2.6.0",
-]
-
-[[package]]
-name = "wasmparser"
 version = "0.209.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07035cc9a9b41e62d3bb3a3815a66ab87c993c06fe1cf6b2a3f2a18499d937db"
@@ -3571,7 +3562,6 @@ name = "wit-bindgen-wrpc"
 version = "0.4.0"
 dependencies = [
  "anyhow",
- "async-trait",
  "bitflags 2.6.0",
  "bytes",
  "futures",
@@ -3585,7 +3575,7 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-wrpc-go"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3730,7 +3720,6 @@ name = "wrpc-runtime-wasmtime"
 version = "0.17.0"
 dependencies = [
  "anyhow",
- "async-trait",
  "bytes",
  "futures",
  "tokio",
@@ -3749,7 +3738,6 @@ name = "wrpc-transport"
 version = "0.26.0"
 dependencies = [
  "anyhow",
- "async-trait",
  "bytes",
  "futures",
  "test-log",
@@ -3811,7 +3799,7 @@ dependencies = [
  "url",
  "wasm-tokio",
  "wasmcloud-component-adapters",
- "wasmparser 0.208.1",
+ "wasmparser 0.212.0",
  "wasmtime",
  "wasmtime-wasi",
  "wit-bindgen-wrpc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3719,7 +3719,7 @@ dependencies = [
 
 [[package]]
 name = "wrpc-introspect"
-version = "0.2.0"
+version = "0.1.0"
 dependencies = [
  "wit-parser 0.212.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,13 +96,11 @@ wrpc-cli = { workspace = true }
 [workspace.dependencies]
 anyhow = { version = "1", default-features = false }
 async-nats = { package = "async-nats-wrpc", version = "0.35.1", default-features = false }
-async-trait = { version = "0.1", default-features = false }
 bitflags = { version = "2", default-features = false }
 bytes = { version = "1", default-features = false }
 clap = { version = "4", default-features = false }
 futures = { version = "0.3", default-features = false }
 heck = { version = "0.5", default-features = false }
-leb128 = { version = "0.2", default-features = false }
 pin-project-lite = { version = "0.2", default-features = false }
 prettyplease = { version = "0.2.20", default-features = false }
 proc-macro2 = { version = "1", default-features = false }
@@ -119,20 +117,18 @@ test-log = { version = "0.2", default-features = false }
 tokio = { version = "1", default-features = false }
 tokio-stream = { version = "0.1", default-features = false }
 tokio-util = { version = "0.7", default-features = false }
-tower = { version = "0.4", default-features = false }
 tracing = { version = "0.1", default-features = false }
 tracing-subscriber = { version = "0.3", default-features = false }
 url = { version = "2", default-features = false }
 wasm-tokio = { version = "0.5.16", default-features = false }
 wasmcloud-component-adapters = { version = "0.9", default-features = false }
-wasmparser = { version = "0.208", default-features = false }
+wasmparser = { version = "0.212", default-features = false }
 wasmtime = { version = "22", default-features = false }
 wasmtime-wasi = { version = "22", default-features = false }
-webpki-roots = { version = "0.26", default-features = false }
 wit-bindgen = { version = "0.27", default-features = false }
 wit-bindgen-core = { version = "0.27", default-features = false }
 wit-bindgen-wrpc = { version = "0.4", default-features = false, path = "./crates/wit-bindgen" }
-wit-bindgen-wrpc-go = { version = "0.1.1", default-features = false, path = "./crates/wit-bindgen-go" }
+wit-bindgen-wrpc-go = { version = "0.2", default-features = false, path = "./crates/wit-bindgen-go" }
 wit-bindgen-wrpc-rust = { version = "0.4", default-features = false, path = "./crates/wit-bindgen-rust" }
 wit-bindgen-wrpc-rust-macro = { version = "0.4", default-features = false, path = "./crates/wit-bindgen-rust-macro" }
 wit-component = { version = "0.212", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,14 +135,14 @@ wasmtime-wasi = { version = "22", default-features = false }
 webpki-roots = { version = "0.26", default-features = false }
 wit-bindgen = { version = "0.27", default-features = false }
 wit-bindgen-core = { version = "0.27", default-features = false }
-wit-bindgen-wrpc = { version = "0.4.0", default-features = false, path = "./crates/wit-bindgen" }
+wit-bindgen-wrpc = { version = "0.4", default-features = false, path = "./crates/wit-bindgen" }
 wit-bindgen-wrpc-go = { version = "0.1.1", default-features = false, path = "./crates/wit-bindgen-go" }
-wit-bindgen-wrpc-rust = { version = "0.4.0", default-features = false, path = "./crates/wit-bindgen-rust" }
-wit-bindgen-wrpc-rust-macro = { version = "0.4.0", default-features = false, path = "./crates/wit-bindgen-rust-macro" }
+wit-bindgen-wrpc-rust = { version = "0.4", default-features = false, path = "./crates/wit-bindgen-rust" }
+wit-bindgen-wrpc-rust-macro = { version = "0.4", default-features = false, path = "./crates/wit-bindgen-rust-macro" }
 wit-component = { version = "0.212", default-features = false }
 wit-parser = { version = "0.212", default-features = false }
 wrpc-cli = { version = "0.1", path = "./crates/cli", default-features = false }
-wrpc-introspect = { version = "0.2", default-features = false, path = "./crates/introspect" }
+wrpc-introspect = { version = "0.1", default-features = false, path = "./crates/introspect" }
 wrpc-runtime-wasmtime = { version = "0.17", path = "./crates/runtime-wasmtime", default-features = false }
 wrpc-transport = { version = "0.26", path = "./crates/transport", default-features = false }
 wrpc-transport-nats = { version = "0.22", path = "./crates/transport-nats", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,11 +37,7 @@ bin = [
     "wit-bindgen-wrpc-go/clap",
     "wit-bindgen-wrpc-rust/clap",
 ]
-nats = [
-    "dep:async-nats",
-    "dep:wrpc-transport-nats",
-    "wrpc-cli/nats",
-]
+nats = ["dep:async-nats", "dep:wrpc-transport-nats", "wrpc-cli/nats"]
 quic = ["dep:wrpc-transport-quic"]
 wasmtime = ["dep:wrpc-runtime-wasmtime"]
 
@@ -99,7 +95,7 @@ wrpc-cli = { workspace = true }
 
 [workspace.dependencies]
 anyhow = { version = "1", default-features = false }
-async-nats = { version = "0.35", git = "https://github.com/rvolosatovs/nats.rs", branch = "feat/command-sender", default-features = false }
+async-nats = { package = "async-nats-wrpc", version = "0.35.1", default-features = false }
 async-trait = { version = "0.1", default-features = false }
 bitflags = { version = "2", default-features = false }
 bytes = { version = "1", default-features = false }

--- a/crates/introspect/Cargo.toml
+++ b/crates/introspect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wrpc-introspect"
-version = "0.2.0"
+version = "0.1.0"
 
 authors.workspace = true
 categories.workspace = true

--- a/crates/runtime-wasmtime/Cargo.toml
+++ b/crates/runtime-wasmtime/Cargo.toml
@@ -12,7 +12,6 @@ repository.workspace = true
 
 [dependencies]
 anyhow = { workspace = true, features = ["std"] }
-async-trait = { workspace = true }
 bytes = { workspace = true }
 futures = { workspace = true, features = ["alloc"] }
 tokio = { workspace = true, features = ["macros"] }

--- a/crates/test-helpers/codegen-macro/Cargo.toml
+++ b/crates/test-helpers/codegen-macro/Cargo.toml
@@ -11,4 +11,4 @@ test = false
 
 [dependencies]
 heck = { workspace = true }
-quote = "1.0.32"
+quote = { workspace = true }

--- a/crates/transport/Cargo.toml
+++ b/crates/transport/Cargo.toml
@@ -15,7 +15,6 @@ frame = []
 
 [dependencies]
 anyhow = { workspace = true, features = ["std"] }
-async-trait = { workspace = true }
 bytes = { workspace = true }
 futures = { workspace = true, features = ["std"] }
 tokio = { workspace = true }

--- a/crates/wit-bindgen-go/Cargo.toml
+++ b/crates/wit-bindgen-go/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wit-bindgen-wrpc-go"
-version = "0.1.1"
+version = "0.2.0"
 description = """
 Go bindings generator for wRPC
 """

--- a/crates/wit-bindgen/Cargo.toml
+++ b/crates/wit-bindgen/Cargo.toml
@@ -17,7 +17,6 @@ repository.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
-async-trait = { workspace = true }
 bitflags = { workspace = true }
 bytes = { workspace = true }
 futures = { workspace = true }

--- a/crates/wit-bindgen/src/examples/_1_interface_imports.rs
+++ b/crates/wit-bindgen/src/examples/_1_interface_imports.rs
@@ -26,7 +26,6 @@ crate::generate!({
     // provided to satisfy imports, since `wit_bindgen_wrpc` crate is not imported here.
     // not required for external use.
     anyhow_path: anyhow,
-    async_trait_path: async_trait,
     bytes_path: bytes,
     futures_path: futures,
     wrpc_transport_path: wrpc_transport,

--- a/crates/wit-bindgen/src/examples/_2_imported_resources.rs
+++ b/crates/wit-bindgen/src/examples/_2_imported_resources.rs
@@ -23,7 +23,6 @@ crate::generate!({
     // provided to satisfy imports, since `wit_bindgen_wrpc` crate is not imported here.
     // not required for external use.
     anyhow_path: anyhow,
-    async_trait_path: async_trait,
     bytes_path: bytes,
     futures_path: futures,
     wrpc_transport_path: wrpc_transport,

--- a/crates/wit-bindgen/src/examples/_3_world_exports.rs
+++ b/crates/wit-bindgen/src/examples/_3_world_exports.rs
@@ -34,7 +34,6 @@ crate::generate!({
     // provided to satisfy imports, since `wit_bindgen_wrpc` crate is not imported here.
     // not required for external use.
     anyhow_path: anyhow,
-    async_trait_path: async_trait,
     bytes_path: bytes,
     futures_path: futures,
     tokio_path: tokio,

--- a/crates/wit-bindgen/src/examples/_4_exported_resources.rs
+++ b/crates/wit-bindgen/src/examples/_4_exported_resources.rs
@@ -27,7 +27,6 @@ crate::generate!({
     // provided to satisfy imports, since `wit_bindgen_wrpc` crate is not imported here,
     // not required for external use.
     anyhow_path: anyhow,
-    async_trait_path: async_trait,
     bytes_path: bytes,
     futures_path: futures,
     wrpc_transport_path: wrpc_transport,

--- a/crates/wit-bindgen/src/lib.rs
+++ b/crates/wit-bindgen/src/lib.rs
@@ -800,7 +800,6 @@ pub use wit_bindgen_wrpc_rust_macro::generate;
 pub mod examples;
 
 pub use anyhow;
-pub use async_trait;
 pub use bitflags;
 pub use bytes;
 pub use futures;


### PR DESCRIPTION
Switch to a nats fork published at https://docs.rs/async-nats-wrpc/latest/async_nats_wrpc/ while https://github.com/nats-io/nats.rs/pull/1267 is in review