### PR TITLE
chore(rust): update crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2379,7 +2379,7 @@ version = "0.0.0"
 dependencies = [
  "codegen-macro",
  "wit-bindgen-core",
- "wit-parser 0.212.0",
+ "wit-parser 0.214.0",
 ]
 
 [[package]]
@@ -2482,9 +2482,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.39.1"
+version = "1.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d040ac2b29ab03b09d4129c2f5bbd012a3ac2f79d38ff506a4bf8dd34b0eac8a"
+checksum = "daa4fb1bc778bd6f04cbfc4bb2d06a7396a8f299dc33ea1900cedaa316f467b1"
 dependencies = [
  "backtrace",
  "bytes",
@@ -2876,28 +2876,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.212.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501940df4418b8929eb6d52f1aade1fdd15a5b86c92453cb696e3c906bd3fc33"
-dependencies = [
- "leb128",
- "wasmparser 0.212.0",
-]
-
-[[package]]
-name = "wasm-encoder"
 version = "0.214.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff694f02a8d7a50b6922b197ae03883fbf18cdb2ae9fbee7b6148456f5f44041"
 dependencies = [
  "leb128",
+ "wasmparser 0.214.0",
 ]
 
 [[package]]
 name = "wasm-metadata"
-version = "0.212.0"
+version = "0.214.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a1849fac257fd76c43268555e73d74848c8dff23975c238c2cbad61cffe5045"
+checksum = "865c5bff5f7a3781b5f92ea4cfa99bb38267da097441cdb09080de1568ef3075"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -2905,8 +2896,8 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "spdx",
- "wasm-encoder 0.212.0",
- "wasmparser 0.212.0",
+ "wasm-encoder 0.214.0",
+ "wasmparser 0.214.0",
 ]
 
 [[package]]
@@ -2937,9 +2928,9 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-component-adapters"
-version = "0.9.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e2f03df5ce84548110521426695ac9d4cc5ab591953d9a6dd2165ce9968055a"
+checksum = "ac4cb3850d012176b644ffade2107c60a7b155b1c0b33a0771c9b39b9b096957"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -2971,9 +2962,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.212.0"
+version = "0.214.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d28bc49ba1e5c5b61ffa7a2eace10820443c4b7d1c0b144109261d14570fdf8"
+checksum = "5309c1090e3e84dad0d382f42064e9933fdaedb87e468cc239f0eabea73ddcb6"
 dependencies = [
  "ahash",
  "bitflags 2.6.0",
@@ -3533,9 +3524,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fabce76bbb8938536c437da0c3e1d4dda9065453f72a68f797c0cb3d67356a28"
+checksum = "89178260ed223de8a5a81f9cff961481dfbbd55b25c17e4dd0b4c8e4b8ae646d"
 dependencies = [
  "wit-bindgen-rt",
  "wit-bindgen-rust-macro",
@@ -3543,29 +3534,29 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-core"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b43fbdd3497c471bbfb6973b1fb9ffe6949f158248cb43171d6f1cf3de7eaa3"
+checksum = "5e3fd9b11c16b9888c1bd159130b1b3487da913c45dbd34d408bfdf81f8a865a"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "wit-parser 0.212.0",
+ "wit-parser 0.214.0",
 ]
 
 [[package]]
 name = "wit-bindgen-rt"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75956ff0a04a87ca0526b07199ce3b9baee899f2e4723b5b63aa296ab172ec52"
+checksum = "d7a37bd9274cb2d4754b915d624447ec0dce9105d174361841c0826efc79ceb9"
 dependencies = [
  "bitflags 2.6.0",
 ]
 
 [[package]]
 name = "wit-bindgen-rust"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf509c4ef97b18ec0218741c8318706ac30ff16bc1731f990319a42bbbcfe8e3"
+checksum = "0f195cd3774ff22f9bbd582a4ab97667c0a47d36ed8ed0c9ed357afe811b564b"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -3579,9 +3570,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-rust-macro"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d6f2e025e38395d71fc1bf064e581b2ad275ce322d6f8d87ddc5e76a7b8c42"
+checksum = "683e47441b5d0a82fc4304619dcc0672bc84ef47de2c85cd493c37cb29de062f"
 dependencies = [
  "anyhow",
  "prettyplease",
@@ -3594,7 +3585,7 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-wrpc"
-version = "0.4.12"
+version = "0.4.13"
 dependencies = [
  "anyhow",
  "bitflags 2.6.0",
@@ -3610,7 +3601,7 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-wrpc-go"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -3622,7 +3613,7 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-wrpc-rust"
-version = "0.4.12"
+version = "0.4.13"
 dependencies = [
  "anyhow",
  "clap",
@@ -3638,7 +3629,7 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-wrpc-rust-macro"
-version = "0.4.12"
+version = "0.4.13"
 dependencies = [
  "anyhow",
  "prettyplease",
@@ -3651,9 +3642,9 @@ dependencies = [
 
 [[package]]
 name = "wit-component"
-version = "0.212.0"
+version = "0.214.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ed5b0f9fc3d6424787d2a49e1142bf954ae4f26ee891992c144f0cfd68c4b7f"
+checksum = "fd9fd46f0e783bf80f1ab7291f9d442fa5553ff0e96cdb71964bd8859b734b55"
 dependencies = [
  "anyhow",
  "bitflags 2.6.0",
@@ -3662,10 +3653,10 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder 0.212.0",
+ "wasm-encoder 0.214.0",
  "wasm-metadata",
- "wasmparser 0.212.0",
- "wit-parser 0.212.0",
+ "wasmparser 0.214.0",
+ "wit-parser 0.214.0",
 ]
 
 [[package]]
@@ -3688,9 +3679,9 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.212.0"
+version = "0.214.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceeb0424aa8679f3fcf2d6e3cfa381f3d6fa6179976a2c05a6249dd2bb426716"
+checksum = "681d526d6ea42e28f9afe9eae2b50e0b0a627aef8822c75eb04078db84d03e57"
 dependencies = [
  "anyhow",
  "id-arena",
@@ -3701,12 +3692,12 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser 0.212.0",
+ "wasmparser 0.214.0",
 ]
 
 [[package]]
 name = "wrpc"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-nats-wrpc",
@@ -3735,7 +3726,7 @@ dependencies = [
 
 [[package]]
 name = "wrpc-cli"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-nats-wrpc",
@@ -3745,14 +3736,14 @@ dependencies = [
 
 [[package]]
 name = "wrpc-introspect"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
- "wit-parser 0.212.0",
+ "wit-parser 0.214.0",
 ]
 
 [[package]]
 name = "wrpc-runtime-wasmtime"
-version = "0.19.3"
+version = "0.19.4"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3764,14 +3755,14 @@ dependencies = [
  "wasm-tokio",
  "wasmtime",
  "wasmtime-wasi",
- "wit-parser 0.212.0",
+ "wit-parser 0.214.0",
  "wrpc-introspect",
  "wrpc-transport",
 ]
 
 [[package]]
 name = "wrpc-transport"
-version = "0.26.6"
+version = "0.26.7"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3787,7 +3778,7 @@ dependencies = [
 
 [[package]]
 name = "wrpc-transport-nats"
-version = "0.22.2"
+version = "0.22.3"
 dependencies = [
  "anyhow",
  "async-nats-wrpc",
@@ -3802,7 +3793,7 @@ dependencies = [
 
 [[package]]
 name = "wrpc-transport-quic"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3822,7 +3813,7 @@ dependencies = [
 
 [[package]]
 name = "wrpc-wasmtime-nats-cli"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "anyhow",
  "async-nats-wrpc",
@@ -3837,12 +3828,12 @@ dependencies = [
  "url",
  "wasm-tokio",
  "wasmcloud-component-adapters",
- "wasmparser 0.212.0",
+ "wasmparser 0.214.0",
  "wasmtime",
  "wasmtime-wasi",
  "wit-bindgen-wrpc",
  "wit-component",
- "wit-parser 0.212.0",
+ "wit-parser 0.214.0",
  "wrpc-cli",
  "wrpc-introspect",
  "wrpc-runtime-wasmtime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wrpc"
-version = "0.3.3"
+version = "0.4.0"
 description = "WebAssembly component-native RPC framework based on WIT"
 
 authors.workspace = true
@@ -124,22 +124,22 @@ tracing-subscriber = { version = "0.3", default-features = false }
 uuid = { version = "1", default-features = false }
 url = { version = "2", default-features = false }
 wasm-tokio = { version = "0.5.16", default-features = false }
-wasmcloud-component-adapters = { version = "0.9", default-features = false }
-wasmparser = { version = "0.212", default-features = false }
+wasmcloud-component-adapters = { version = "0.11", default-features = false }
+wasmparser = { version = "0.214", default-features = false }
 wasmtime = { version = "22", default-features = false }
 wasmtime-wasi = { version = "22", default-features = false }
-wit-bindgen = { version = "0.27", default-features = false }
-wit-bindgen-core = { version = "0.27", default-features = false }
-wit-bindgen-wrpc = { version = "0.4.12", default-features = false, path = "./crates/wit-bindgen" }
+wit-bindgen = { version = "0.28", default-features = false }
+wit-bindgen-core = { version = "0.28", default-features = false }
+wit-bindgen-wrpc = { version = "0.4.13", default-features = false, path = "./crates/wit-bindgen" }
 wit-bindgen-wrpc-go = { version = "0.2", default-features = false, path = "./crates/wit-bindgen-go" }
-wit-bindgen-wrpc-rust = { version = "0.4.12", default-features = false, path = "./crates/wit-bindgen-rust" }
-wit-bindgen-wrpc-rust-macro = { version = "0.4.12", default-features = false, path = "./crates/wit-bindgen-rust-macro" }
-wit-component = { version = "0.212", default-features = false }
-wit-parser = { version = "0.212", default-features = false }
-wrpc-cli = { version = "0.2", path = "./crates/cli", default-features = false }
-wrpc-introspect = { version = "0.1", default-features = false, path = "./crates/introspect" }
-wrpc-runtime-wasmtime = { version = "0.19.3", path = "./crates/runtime-wasmtime", default-features = false }
-wrpc-transport = { version = "0.26.6", path = "./crates/transport", default-features = false }
-wrpc-transport-nats = { version = "0.22.2", path = "./crates/transport-nats", default-features = false }
-wrpc-transport-quic = { version = "0.1", path = "./crates/transport-quic", default-features = false }
-wrpc-wasmtime-nats-cli = { version = "0.3.3", path = "./crates/wasmtime-nats-cli", default-features = false }
+wit-bindgen-wrpc-rust = { version = "0.4.13", default-features = false, path = "./crates/wit-bindgen-rust" }
+wit-bindgen-wrpc-rust-macro = { version = "0.4.13", default-features = false, path = "./crates/wit-bindgen-rust-macro" }
+wit-component = { version = "0.214", default-features = false }
+wit-parser = { version = "0.214", default-features = false }
+wrpc-cli = { version = "0.2.1", path = "./crates/cli", default-features = false }
+wrpc-introspect = { version = "0.1.1", default-features = false, path = "./crates/introspect" }
+wrpc-runtime-wasmtime = { version = "0.19.4", path = "./crates/runtime-wasmtime", default-features = false }
+wrpc-transport = { version = "0.26.7", path = "./crates/transport", default-features = false }
+wrpc-transport-nats = { version = "0.22.3", path = "./crates/transport-nats", default-features = false }
+wrpc-transport-quic = { version = "0.1.1", path = "./crates/transport-quic", default-features = false }
+wrpc-wasmtime-nats-cli = { version = "0.3.4", path = "./crates/wasmtime-nats-cli", default-features = false }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wrpc-cli"
-version = "0.2.0"
+version = "0.2.1"
 description = "wRPC CLI utilities"
 
 authors.workspace = true

--- a/crates/introspect/Cargo.toml
+++ b/crates/introspect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wrpc-introspect"
-version = "0.1.0"
+version = "0.1.1"
 description = "Component type introspection for wRPC"
 
 authors.workspace = true

--- a/crates/runtime-wasmtime/Cargo.toml
+++ b/crates/runtime-wasmtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wrpc-runtime-wasmtime"
-version = "0.19.3"
+version = "0.19.4"
 description = "wRPC wasmtime integration"
 
 authors.workspace = true

--- a/crates/transport-nats/Cargo.toml
+++ b/crates/transport-nats/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wrpc-transport-nats"
-version = "0.22.2"
+version = "0.22.3"
 description = "wRPC NATS transport"
 
 authors.workspace = true

--- a/crates/transport-quic/Cargo.toml
+++ b/crates/transport-quic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wrpc-transport-quic"
-version = "0.1.0"
+version = "0.1.1"
 description = "wRPC QUIC transport"
 
 authors.workspace = true

--- a/crates/transport/Cargo.toml
+++ b/crates/transport/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wrpc-transport"
-version = "0.26.6"
+version = "0.26.7"
 description = "wRPC core transport functionality"
 
 authors.workspace = true

--- a/crates/wasmtime-nats-cli/Cargo.toml
+++ b/crates/wasmtime-nats-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wrpc-wasmtime-nats-cli"
-version = "0.3.3"
+version = "0.3.4"
 description = "wRPC Wasmtime NATS CLI"
 
 authors.workspace = true

--- a/crates/wit-bindgen-go/Cargo.toml
+++ b/crates/wit-bindgen-go/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wit-bindgen-wrpc-go"
-version = "0.2.0"
+version = "0.2.1"
 description = """
 Go bindings generator for wRPC
 """

--- a/crates/wit-bindgen-rust-macro/Cargo.toml
+++ b/crates/wit-bindgen-rust-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wit-bindgen-wrpc-rust-macro"
-version = "0.4.12"
+version = "0.4.13"
 description = """
 Procedural macro paired with the `wit-bindgen-wrpc` crate.
 """

--- a/crates/wit-bindgen-rust/Cargo.toml
+++ b/crates/wit-bindgen-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wit-bindgen-wrpc-rust"
-version = "0.4.12"
+version = "0.4.13"
 description = """
 Rust bindings generator for wRPC, typically used through
 the `wit-bindgen-wrpc` crate's `generate!` macro.

--- a/crates/wit-bindgen/Cargo.toml
+++ b/crates/wit-bindgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wit-bindgen-wrpc"
-version = "0.4.12"
+version = "0.4.13"
 description = """
 Rust bindings generator for wRPC.
 """


### PR DESCRIPTION
a few last-minute dep updates and update of the workspace crate versions

held off the wasmtime 23 update due to https://github.com/bytecodealliance/wasmtime/pull/8786, which will require a bit more looking into to integrate in wRPC and downstream crates