### PR TITLE
fix(go): Closing nats subscriptions

### DIFF
--- a/go/nats/client.go
+++ b/go/nats/client.go
@@ -151,6 +151,12 @@ func (w *paramWriter) publish(p []byte) (int, error) {
 		if err != nil {
 			return 0, fmt.Errorf("failed to subscribe on Rx subject: %w", err)
 		}
+		defer func() {
+			if err := sub.Unsubscribe(); err != nil {
+				slog.Error("failed to unsubscribe from Rx subject", "err", err)
+			}
+		}()
+
 		slog.DebugContext(w.ctx, "publishing handshake", "rx", m.Reply)
 		if err := w.nc.PublishMsg(m); err != nil {
 			return 0, fmt.Errorf("failed to send initial payload chunk: %w", err)


### PR DESCRIPTION
We are leaving subscriptions open in 2 situations:
- Handshake: Missing Unsubscribe
- When `streamWriter` hands off a subscription to `indexedStreamWriter`: The Unsubscribe codepath is only in `streamWriter` via the `Close` method

This PR adds the missing `Unsubscribe` for handshakes, and makes so subscriptions handed of to `indexedStreamWriter` are closed by `streamWriter` during its `Close` call.