### PR TITLE
chore: Update crate homepage and repository

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,9 @@ repository.workspace = true
 authors = ["Roman Volosatovs <rvolosatovs@riseup.net>"]
 categories = ["wasm"]
 edition = "2021"
-homepage = "https://github.com/wrpc/wrpc"
+homepage = "https://github.com/bytecodealliance/wrpc"
 license = "Apache-2.0 WITH LLVM-exception"
-repository = "https://github.com/wrpc/wrpc"
+repository = "https://github.com/bytecodealliance/wrpc"
 
 [workspace]
 members = ["crates/*", "examples/rust/*"]


### PR DESCRIPTION
I noticed this was pointing to `wrpc/wrpc` still, and while GitHub handles that correctly, it would probably be better to just correct the location.