### PR TITLE
fix(wit-bindgen-wrpc): Use eprintln instead of println for output

### DIFF
--- a/src/bin/wit-bindgen-wrpc.rs
+++ b/src/bin/wit-bindgen-wrpc.rs
@@ -91,7 +91,7 @@ fn main() -> Result<()> {
             Some(path) => path.join(name),
             None => name.into(),
         };
-        println!("Generating {dst:?}");
+        eprintln!("Generating {dst:?}");
 
         if opt.check {
             let prev = std::fs::read(&dst).with_context(|| format!("failed to read {dst:?}"))?;


### PR DESCRIPTION
`eprintln!` feels more appropriate here, especially in cases where other tools may be calling into `wit-bindgen-wrpc`.