### PR TITLE
feat(go-nats): remove error channel and `indexedStreamReader`

### DIFF
--- a/go/nats/client.go
+++ b/go/nats/client.go
@@ -1,12 +1,12 @@
 package wrpcnats
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 
 	wrpc "github.com/bytecodealliance/wrpc/go"
 	"github.com/nats-io/nats.go"
@@ -21,10 +21,6 @@ func HeaderFromContext(ctx context.Context) (nats.Header, bool) {
 
 func ContextWithHeader(ctx context.Context, header nats.Header) context.Context {
 	return context.WithValue(ctx, headerKey{}, header)
-}
-
-func errorSubject(prefix string) string {
-	return fmt.Sprintf("%s.error", prefix)
 }
 
 func paramSubject(prefix string) string {
@@ -80,36 +76,6 @@ func subscribe(conn *nats.Conn, prefix string, f func(context.Context, []byte), 
 		ctx = ContextWithHeader(ctx, m.Header)
 		f(ctx, m.Data)
 	})
-}
-
-func transmitError(nc *nats.Conn, subject string, err error) error {
-	var buf bytes.Buffer
-	if err := wrpc.WriteString(fmt.Sprintf("%s", err), &buf); err != nil {
-		slog.Warn("failed to encode handling error", "err", err)
-		buf.Reset()
-		if err := wrpc.WriteString(fmt.Sprintf("failed to encode error: %s", err), &buf); err != nil {
-			slog.Warn("failed to encode handling error encoding error", "err", err)
-			buf.Reset()
-		}
-	}
-	maxPayload := nc.MaxPayload()
-	maxPayload = min(maxPayload, int64(buf.Len()))
-	b := buf.Bytes()
-	var tail []byte
-	b, tail = b[:maxPayload], b[maxPayload:]
-	slog.Debug("transmitting initial error chunk")
-	if err := nc.Publish(subject, b); err != nil {
-		return fmt.Errorf("failed to send initial error chunk: %w", err)
-	}
-	for len(tail) > 0 {
-		maxPayload = min(maxPayload, int64(len(tail)))
-		b, tail = b[:maxPayload], b[maxPayload:]
-		slog.Debug("transmitting error chunk")
-		if err := nc.Publish(subject, b); err != nil {
-			return fmt.Errorf("failed to send error chunk: %w", err)
-		}
-	}
-	return nil
 }
 
 type Client struct {
@@ -235,14 +201,18 @@ func (w *resultWriter) Index(path ...uint32) (wrpc.IndexWriter, error) {
 	return &resultWriter{nc: w.nc, tx: indexPath(w.tx, path...)}, nil
 }
 
-type subReader struct {
-	ctx    context.Context
-	sub    *nats.Subscription
-	cancel func()
-	buf    []byte
+type streamReader struct {
+	ctx context.Context
+	sub *nats.Subscription
+	// poor man's [`std::sync::Arc`](https://doc.rust-lang.org/std/sync/struct.Arc.html)
+	nestMu  *sync.Mutex
+	nestRef *atomic.Int64
+	nest    map[string]*nats.Subscription
+	path    string
+	buf     []byte
 }
 
-func (r *subReader) Read(p []byte) (int, error) {
+func (r *streamReader) Read(p []byte) (int, error) {
 	if len(r.buf) > 0 {
 		n := copy(p, r.buf)
 		slog.Debug("copied bytes from buffer", "requested", len(p), "buffered", len(r.buf), "copied", n)
@@ -259,7 +229,7 @@ func (r *subReader) Read(p []byte) (int, error) {
 	return n, nil
 }
 
-func (r *subReader) ReadByte() (byte, error) {
+func (r *streamReader) ReadByte() (byte, error) {
 	if len(r.buf) > 0 {
 		b := r.buf[0]
 		slog.Debug("copied byte from buffer", "buffered", len(r.buf))
@@ -280,124 +250,25 @@ func (r *subReader) ReadByte() (byte, error) {
 	}
 }
 
-type streamReader struct {
-	*subReader
-	err    *nats.Subscription
-	nest   map[string]*nats.Subscription
-	nestMu sync.Mutex
-}
-
 func (r *streamReader) Close() (err error) {
-	defer r.cancel()
-
-	r.nestMu.Lock()
-	defer r.nestMu.Unlock()
-	defer func() {
-		if sErr := r.err.Unsubscribe(); sErr != nil {
-			if err == nil {
-				err = fmt.Errorf("failed to unsubscribe from error subject: %w", err)
-			} else {
-				slog.Error("failed to unsubscribe from error subject", "err", err)
+	refs := r.nestRef.Add(-1)
+	if refs == 0 {
+		// since this is the only reference to `nest`, no need to lock the mutex
+		var errs []error
+		for path, sub := range r.nest {
+			if err := sub.Unsubscribe(); err != nil {
+				errs = append(errs, fmt.Errorf("failed to unsubscribe from nested path `%s`: %w", path, err))
 			}
 		}
-	}()
-	for path, sub := range r.nest {
-		path := path
-		sub := sub
-		defer func() {
-			if sErr := sub.Unsubscribe(); sErr != nil {
-				if err == nil {
-					err = fmt.Errorf("failed to unsubscribe from nested path `%s`: %w", path, sErr)
-				} else {
-					slog.Error("failed to unsubscribe from nested path", "path", path, "err", sErr)
-				}
-			}
-		}()
+		if len(errs) > 0 {
+			return fmt.Errorf("%v", errs)
+		}
 	}
-	p, n, err := r.err.Pending()
-	if err != nil {
-		return fmt.Errorf("failed to check pending error bytes: %w", err)
-	}
-	if p == 0 {
-		return nil
-	}
-	if n == 0 {
-		return errors.New("received an empty error")
-	}
-	slog.DebugContext(r.ctx, "reading error string")
-	s, err := wrpc.ReadString(&subReader{
-		ctx: r.ctx,
-		sub: r.err,
-	})
-	if err == context.Canceled {
-		return err
-	}
-	if err != nil {
-		return fmt.Errorf("failed to read error string: %w", err)
-	}
-	return errors.New(s)
-}
-
-type indexedStreamReader struct {
-	*streamReader
-	sub  *nats.Subscription
-	path string
-	buf  []byte
+	return nil
 }
 
 func (r *streamReader) Index(path ...uint32) (wrpc.IndexReader, error) {
-	s := indexPath("", path...)
-	r.nestMu.Lock()
-	defer r.nestMu.Unlock()
-	sub, ok := r.nest[s]
-	if !ok {
-		return nil, errors.New("unknown subscription")
-	}
-	delete(r.nest, s)
-	return &indexedStreamReader{
-		r, sub, s, nil,
-	}, nil
-}
-
-func (r *indexedStreamReader) Read(p []byte) (int, error) {
-	if len(r.buf) > 0 {
-		n := copy(p, r.buf)
-		slog.Debug("copied bytes from buffer", "requested", len(p), "buffered", len(r.buf), "copied", n)
-		r.buf = r.buf[n:]
-		return n, nil
-	}
-	slog.Debug("receiving next byte chunk", "path", r.path)
-	msg, err := r.sub.NextMsgWithContext(r.ctx)
-	if err != nil {
-		return 0, err
-	}
-	n := copy(p, msg.Data)
-	r.buf = msg.Data[n:]
-	return n, nil
-}
-
-func (r *indexedStreamReader) ReadByte() (byte, error) {
-	if len(r.buf) > 0 {
-		b := r.buf[0]
-		slog.Debug("copied byte from buffer", "buffered", len(r.buf))
-		r.buf = r.buf[1:]
-		return b, nil
-	}
-	for {
-		slog.Debug("receiving next byte chunk", "path", r.path)
-		msg, err := r.sub.NextMsgWithContext(r.ctx)
-		if err != nil {
-			return 0, err
-		}
-		if len(msg.Data) == 0 {
-			continue
-		}
-		r.buf = msg.Data[1:]
-		return msg.Data[0], nil
-	}
-}
-
-func (r *indexedStreamReader) Index(path ...uint32) (wrpc.IndexReader, error) {
+	r.nestRef.Add(1)
 	s := indexPath(r.path, path...)
 	r.nestMu.Lock()
 	defer r.nestMu.Unlock()
@@ -406,21 +277,23 @@ func (r *indexedStreamReader) Index(path ...uint32) (wrpc.IndexReader, error) {
 		return nil, errors.New("unknown subscription")
 	}
 	delete(r.nest, s)
-	return &indexedStreamReader{
-		r.streamReader, sub, s, nil,
+	return &streamReader{
+		ctx:     r.ctx,
+		sub:     sub,
+		nestMu:  r.nestMu,
+		nestRef: r.nestRef,
+		nest:    r.nest,
+		path:    s,
 	}, nil
 }
 
 func (c *Client) Invoke(ctx context.Context, instance string, name string, f func(wrpc.IndexWriter, wrpc.IndexReadCloser) error, subs ...wrpc.SubscribePath) (err error) {
-	ctx, cancel := context.WithCancel(ctx)
-
 	rx := nats.NewInbox()
 
 	resultRx := resultSubject(rx)
 	slog.Debug("subscribing on result subject", "subject", resultRx)
 	resultSub, err := c.conn.SubscribeSync(resultRx)
 	if err != nil {
-		cancel()
 		return fmt.Errorf("failed to subscribe on result subject `%s`: %w", resultRx, err)
 	}
 	defer func() {
@@ -433,21 +306,12 @@ func (c *Client) Invoke(ctx context.Context, instance string, name string, f fun
 		}
 	}()
 
-	errRx := errorSubject(rx)
-	slog.Debug("subscribing on error subject", "subject", errRx)
-	errSub, err := c.conn.SubscribeSync(errRx)
-	if err != nil {
-		cancel()
-		return fmt.Errorf("failed to subscribe on error subject `%s`: %w", errRx, err)
-	}
-
 	nest := make(map[string]*nats.Subscription, len(subs))
 	for _, path := range subs {
 		s := subscribePath(resultRx, path)
 		slog.Debug("subscribing on nested result subject", "subject", s)
 		sub, err := c.conn.SubscribeSync(s)
 		if err != nil {
-			cancel()
 			return fmt.Errorf("failed to subscribe on nested result subject `%s`: %w", s, err)
 		}
 		nest[subscribePath("", path)] = sub
@@ -460,31 +324,24 @@ func (c *Client) Invoke(ctx context.Context, instance string, name string, f fun
 		rx:  rx,
 		tx:  invocationSubject(c.prefix, instance, name),
 	}
-	if err = f(w, &streamReader{
-		subReader: &subReader{
-			ctx:    ctx,
-			sub:    resultSub,
-			cancel: cancel,
-		},
-		err:  errSub,
-		nest: nest,
-	}); err != nil && w.init {
-		if err := transmitError(c.conn, errorSubject(w.tx), err); err != nil {
-			slog.Warn("failed to send error to server", "err", err)
-		}
-	}
-	return err
+	nestRef := &atomic.Int64{}
+	nestRef.Add(1)
+	return f(w, &streamReader{
+		ctx:     ctx,
+		sub:     resultSub,
+		nestMu:  &sync.Mutex{},
+		nestRef: nestRef,
+		nest:    nest,
+	})
 }
 
 func (c *Client) Serve(instance string, name string, f func(context.Context, wrpc.IndexWriter, wrpc.IndexReadCloser) error, subs ...wrpc.SubscribePath) (stop func() error, err error) {
 	sub, err := c.conn.Subscribe(invocationSubject(c.prefix, instance, name), func(m *nats.Msg) {
 		ctx := context.Background()
-		ctx, cancel := context.WithCancel(ctx)
 		ctx = ContextWithHeader(ctx, m.Header)
 
 		slog.Debug("received invocation", "instance", instance, "name", name, "payload", m.Data, "reply", m.Reply)
 		if m.Reply == "" {
-			cancel()
 			slog.Warn("peer did not specify a reply subject")
 			return
 		}
@@ -495,7 +352,6 @@ func (c *Client) Serve(instance string, name string, f func(context.Context, wrp
 		slog.Debug("subscribing on parameter subject", "subject", paramRx)
 		paramSub, err := c.conn.SubscribeSync(paramRx)
 		if err != nil {
-			cancel()
 			slog.Warn("failed to subscribe on parameter subject", "subject", paramRx, "err", err)
 			return
 		}
@@ -505,55 +361,41 @@ func (c *Client) Serve(instance string, name string, f func(context.Context, wrp
 			}
 		}()
 
-		errRx := errorSubject(rx)
-		slog.Debug("subscribing on error subject", "subject", errRx)
-		errSub, err := c.conn.SubscribeSync(errRx)
-		if err != nil {
-			cancel()
-			slog.Warn("failed to subscribe on error subject", "subject", errRx, "err", err)
-			return
-		}
-
 		nest := make(map[string]*nats.Subscription, len(subs))
 		for _, path := range subs {
 			s := subscribePath(paramRx, path)
 			slog.Debug("subscribing on nested parameter subject", "subject", s)
 			sub, err := c.conn.SubscribeSync(s)
 			if err != nil {
-				cancel()
 				slog.Warn("failed to subscribe on nested parameter subject", "subject", s, "err", err)
 				return
 			}
 			nest[subscribePath("", path)] = sub
 		}
 
-		slog.DebugContext(ctx, "publishing handshake accept", "subject", m.Reply, "reply", rx)
+		slog.DebugContext(ctx, "publishing handshake response", "subject", m.Reply, "reply", rx)
 		accept := nats.NewMsg(m.Reply)
 		accept.Reply = rx
 		if err := c.conn.PublishMsg(accept); err != nil {
-			cancel()
 			slog.Error("failed to send handshake", "err", err)
 			return
 		}
 
 		slog.Debug("calling server handler")
+		nestRef := &atomic.Int64{}
+		nestRef.Add(1)
 		if err := f(ctx, &resultWriter{
 			nc: c.conn,
 			tx: resultSubject(m.Reply),
 		}, &streamReader{
-			subReader: &subReader{
-				ctx:    ctx,
-				sub:    paramSub,
-				buf:    m.Data,
-				cancel: cancel,
-			},
-			err:  errSub,
-			nest: nest,
+			ctx:     ctx,
+			sub:     paramSub,
+			buf:     m.Data,
+			nestMu:  &sync.Mutex{},
+			nestRef: nestRef,
+			nest:    nest,
 		}); err != nil {
 			slog.Warn("failed to handle invocation", "err", err)
-			if err := transmitError(c.conn, errorSubject(m.Reply), err); err != nil {
-				slog.Warn("failed to send error to client", "err", err)
-			}
 			return
 		}
 		slog.Debug("successfully finished serving invocation")


### PR DESCRIPTION
- Remove usage of `.errors` channel removed in latest wRPC-over-NATS versions
- Remove `indexedStreamReader` abstraction, instead just use `streamReader`
- Count references to nested subscriptions and unsub only once all of them are dropped (possibly fixes issue originally reported in #214, still getting there)

cc @lxfontes 