### PR TITLE
fix(wit-bindgen-wrpc): clear out variant decoder internal state after use

### DIFF
--- a/crates/wit-bindgen-rust/src/interface.rs
+++ b/crates/wit-bindgen-rust/src/interface.rs
@@ -2090,7 +2090,7 @@ mod {mod_name} {{
                 }}
             }};
 
-            match state {{"#
+            let decoded = match state {{"#
                 );
                 for Case {
                     name: case_name,
@@ -2107,7 +2107,7 @@ mod {mod_name} {{
                             let Some(payload) = dec.decode(src)? else {{
                                 return Ok(None)
                             }};
-                            Ok(Some(super::{name}::{case}(payload)))
+                            Some(super::{name}::{case}(payload))
                         }},"
                         );
                     }
@@ -2115,7 +2115,11 @@ mod {mod_name} {{
                 uwriteln!(
                     self.src,
                     r#"
-            }}
+            }};
+
+            let _ = self.0.take();
+
+            Ok(decoded)
         }}
     }}
 }}"#,

--- a/tests/go.rs
+++ b/tests/go.rs
@@ -130,6 +130,30 @@ async fn go_bindgen() -> anyhow::Result<()> {
             "{v:?}"
         );
 
+        info!("calling `wrpc-test:integration/sync.with-variant-list`");
+        let v = sync::with_variant_list(&client, None)
+            .await
+            .context("failed to call `wrpc-test:integration/sync.with-variant-list`")?;
+        ensure!(
+            v == [
+                Var::Empty,
+                Var::Var(Rec {
+                    nested: RecNested {
+                        foo: "foo".to_string()
+                    }
+                }),
+                Var::Empty,
+                Var::Empty,
+                Var::Empty,
+                Var::Var(Rec {
+                    nested: RecNested {
+                        foo: "bar".to_string()
+                    }
+                }),
+            ],
+            "{v:?}"
+        );
+
         info!("calling `wrpc-test:integration/sync.with-record`");
         let v = sync::with_record(&client, None)
             .await

--- a/tests/go/sync.go
+++ b/tests/go/sync.go
@@ -49,6 +49,26 @@ func (SyncHandler) WithFlags(ctx context.Context, a, b, c bool) (*sync.Abc, erro
 	return &sync.Abc{A: a, B: b, C: c}, nil
 }
 
+func (SyncHandler) WithVariantList(ctx context.Context) ([]*sync.Var, error) {
+	slog.DebugContext(ctx, "handling `with-variant-list`")
+	return []*sync.Var{
+		sync.NewVarEmpty(),
+		sync.NewVarVar(&sync.Rec{
+			Nested: &sync.RecNested{
+				Foo: "foo",
+			},
+		}),
+		sync.NewVarEmpty(),
+		sync.NewVarEmpty(),
+		sync.NewVarEmpty(),
+		sync.NewVarVar(&sync.Rec{
+			Nested: &sync.RecNested{
+				Foo: "bar",
+			},
+		}),
+	}, nil
+}
+
 func (SyncHandler) WithVariantOption(ctx context.Context, ok bool) (*sync.Var, error) {
 	slog.DebugContext(ctx, "handling `with-variant-option`", "ok", ok)
 	if ok {

--- a/tests/go/sync_test.go
+++ b/tests/go/sync_test.go
@@ -185,6 +185,37 @@ func TestSync(t *testing.T) {
 		}
 	}
 	{
+		v, shutdown, err := sync.WithVariantList(ctx, client)
+		if err != nil {
+			t.Errorf("failed to call `wrpc-test:integration/sync.with-variant-list`: %s", err)
+			return
+		}
+		expected := []*sync.Var{
+			sync.NewVarEmpty(),
+			sync.NewVarVar(&sync.Rec{
+				Nested: &sync.RecNested{
+					Foo: "foo",
+				},
+			}),
+			sync.NewVarEmpty(),
+			sync.NewVarEmpty(),
+			sync.NewVarEmpty(),
+			sync.NewVarVar(&sync.Rec{
+				Nested: &sync.RecNested{
+					Foo: "bar",
+				},
+			}),
+		}
+		if !reflect.DeepEqual(v, expected) {
+			t.Errorf("expected: %v, got: %#v", expected, v)
+			return
+		}
+		if err := shutdown(); err != nil {
+			t.Errorf("failed to shutdown: %s", err)
+			return
+		}
+	}
+	{
 		v, shutdown, err := sync.WithRecord(ctx, client)
 		if err != nil {
 			t.Errorf("failed to call `wrpc-test:integration/sync.with-record`: %s", err)

--- a/tests/wit/test.wit
+++ b/tests/wit/test.wit
@@ -29,6 +29,7 @@ interface sync {
     numbers: func() -> tuple<u8, u16, u32, u64, s8, s16, s32, s64, f32, f64>;
     with-flags: func(a: bool, b: bool, c: bool) -> abc;
     with-variant-option: func(ok: bool) -> option<var>;
+    with-variant-list: func() -> list<var>;
     with-record: func() -> rec;
     with-record-list: func(n: u8) -> list<rec>;
     with-record-tuple: func() -> tuple<rec, rec>;


### PR DESCRIPTION
This commit fixes a bug which manifests itself when decoding a list of enums that may have separate internal decoder objects to use.

The issue is that storing the internal state inside the bindgen'd `Decoder` becomes a problem on the *second* (or subsequent) elements of a list of the given enum.

Given a `vec![SomeEnum::X, SomeEnum::Y]` the saved "state" for the first becomes the first decoder (i.e. the decoder for `SomeEnum::X`). When it comes time to parse the discriminant and bytes for `Y` the existence of the `state` causes a short circuit.

As the (wrong) decoder will generally try to process some bytes, you lose bytes from the input and then bytes are left over at the next attempt to decode (and then an error occurs). How this manifests is obviously specific to the enum, (wrong) decoder, and involved variants, how they are decoded -- i.e. where the decoding will fail.

This only happens for generating bindings for variant types (i.e. Rust enums), which use the `PayloadDecoder` machinery to dynamically pick *which* payload decoder to use, depending on the discriminant read.