### PR TITLE
feat(transport): Adds support for a vec of options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3637,7 +3637,7 @@ dependencies = [
 
 [[package]]
 name = "wrpc"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -3713,7 +3713,7 @@ dependencies = [
 
 [[package]]
 name = "wrpc-transport"
-version = "0.26.7"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3855,3 +3855,8 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
+
+[[patch.unused]]
+name = "wasm-tokio"
+version = "0.6.0"
+source = "git+https://github.com/thomastaylor312/wasm-tokio.git?branch=fix/missing_impls#d07b15ba9641f5b7b87fd8e6221e532d0e54d8d9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "WebAssembly component-native RPC framework based on WIT"
 name = "wrpc"
-version = "0.10.0"
+version = "0.10.1"
 
 authors.workspace = true
 categories.workspace = true
@@ -139,7 +139,10 @@ wit-parser = { version = "0.215", default-features = false }
 wrpc-cli = { version = "0.3", path = "./crates/cli", default-features = false }
 wrpc-introspect = { version = "0.3", default-features = false, path = "./crates/introspect" }
 wrpc-runtime-wasmtime = { version = "0.21", path = "./crates/runtime-wasmtime", default-features = false }
-wrpc-transport = { version = "0.26.7", path = "./crates/transport", default-features = false }
+wrpc-transport = { version = "0.27.0", path = "./crates/transport", default-features = false }
 wrpc-transport-nats = { version = "0.23", path = "./crates/transport-nats", default-features = false }
 wrpc-transport-quic = { version = "0.1.1", path = "./crates/transport-quic", default-features = false }
 wrpc-wasmtime-nats-cli = { version = "0.7", path = "./crates/wasmtime-nats-cli", default-features = false }
+
+[patch.crates-io]
+wasm-tokio = { git = "https://github.com/thomastaylor312/wasm-tokio.git", branch = "fix/missing_impls" }

--- a/crates/transport/Cargo.toml
+++ b/crates/transport/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wrpc-transport"
-version = "0.26.7"
+version = "0.27.0"
 description = "wRPC core transport functionality"
 
 authors.workspace = true

--- a/crates/transport/src/value.rs
+++ b/crates/transport/src/value.rs
@@ -17,7 +17,7 @@ use tokio::sync::{mpsc, oneshot};
 use tokio::task::JoinSet;
 use tokio::{select, try_join};
 use tokio_stream::wrappers::ReceiverStream;
-use tokio_util::codec::{Encoder as _, FramedRead};
+use tokio_util::codec::{Decoder, Encoder as _, FramedRead};
 use tokio_util::io::StreamReader;
 use tracing::{instrument, trace};
 use wasm_tokio::cm::{
@@ -260,6 +260,15 @@ impl_deferred_sync!(CoreVecDecoder<Leb128DecoderU64>);
 impl_deferred_sync!(CoreVecDecoder<Leb128DecoderI128>);
 impl_deferred_sync!(CoreVecDecoder<Leb128DecoderU128>);
 impl_deferred_sync!(CoreVecDecoder<UnitCodec>);
+
+impl<T, W> Deferred<T> for CoreVecDecoder<OptionDecoder<W>>
+where
+    W: Deferred<T> + Decoder,
+{
+    fn take_deferred(&mut self) -> Option<DeferredFn<T>> {
+        None
+    }
+}
 
 pub struct SyncCodec<T>(pub T);
 


### PR DESCRIPTION
I discovered this when trying to implement `wasi:keyvalue/batch`, which returns a list of optionals. There was no `Deferred` impl for an option decoder, so this adds a simple implementation for it