### PR TITLE
fix(rs-nats): close streams on drop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3714,7 +3714,7 @@ dependencies = [
 
 [[package]]
 name = "wrpc"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -3806,7 +3806,7 @@ dependencies = [
 
 [[package]]
 name = "wrpc-transport-nats"
-version = "0.23.1"
+version = "0.23.2"
 dependencies = [
  "anyhow",
  "async-nats",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 description = "WebAssembly component-native RPC framework based on WIT"
 name = "wrpc"
-version = "0.11.0"
+version = "0.11.1"
 
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true
+homepage.workspace = true
 license.workspace = true
 repository.workspace = true
 
@@ -140,6 +141,6 @@ wrpc-cli = { version = "0.3", path = "./crates/cli", default-features = false }
 wrpc-introspect = { version = "0.3", default-features = false, path = "./crates/introspect" }
 wrpc-runtime-wasmtime = { version = "0.22", path = "./crates/runtime-wasmtime", default-features = false }
 wrpc-transport = { version = "0.26.8", path = "./crates/transport", default-features = false }
-wrpc-transport-nats = { version = "0.23.1", path = "./crates/transport-nats", default-features = false }
+wrpc-transport-nats = { version = "0.23.2", path = "./crates/transport-nats", default-features = false }
 wrpc-transport-quic = { version = "0.1.2", path = "./crates/transport-quic", default-features = false }
 wrpc-wasmtime-nats-cli = { version = "0.8", path = "./crates/wasmtime-nats-cli", default-features = false }

--- a/crates/transport-nats/Cargo.toml
+++ b/crates/transport-nats/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wrpc-transport-nats"
-version = "0.23.1"
+version = "0.23.2"
 description = "wRPC NATS transport"
 
 authors.workspace = true


### PR DESCRIPTION
This ensures that clients are notified early of connection drop, effectively this is "connection reset by peer"

cc @thomastaylor312