### PR TITLE
ci: use `#` as version separator for root crate

### DIFF
--- a/.github/workflows/wrpc.yml
+++ b/.github/workflows/wrpc.yml
@@ -403,7 +403,7 @@ jobs:
 
       - name: publish wRPC to crates.io
         run: |
-          pkgver=$(cargo pkgid | cut -d '@' -f 2)
+          pkgver=$(cargo pkgid | cut -d '#' -f 2)
           tagver="${{ steps.ctx.outputs.version }}"
           if ! [ "$pkgver" = "$tagver" ]; then
             echo "version mismatch, $pkgver (package) != $tagver (tag)"


### PR DESCRIPTION
Apparently, `cargo pkgid` uses `@` as separator for workspace subcrate versions and `#` for the root crate. TIL