### PR TITLE
feat(rs-transport): implement framed transport over TCP and UDS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -802,6 +802,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
+name = "fastrand"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
+
+[[package]]
 name = "fd-lock"
 version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2346,6 +2352,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
+name = "tempfile"
+version = "3.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3704,6 +3723,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
+ "tempfile",
  "test-log",
  "tokio",
  "tracing",
@@ -3773,6 +3793,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "futures",
+ "pin-project-lite",
  "send-future",
  "test-log",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3788,7 +3788,7 @@ dependencies = [
 
 [[package]]
 name = "wrpc-transport"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,9 +90,11 @@ quinn = { workspace = true, features = [
 ] }
 rcgen = { workspace = true, features = ["crypto", "ring", "zeroize"] }
 rustls = { workspace = true, features = ["logging", "ring"] }
+tempfile = { workspace = true }
 test-log = { workspace = true, features = ["color", "log", "trace"] }
 tokio = { workspace = true, features = ["process", "rt-multi-thread"] }
 wrpc-cli = { workspace = true }
+wrpc-transport = { workspace = true, features = ["frame"] }
 
 [workspace.dependencies]
 anyhow = { version = "1", default-features = false }
@@ -115,6 +117,7 @@ send-future = { version = "0.1", default-features = false }
 serde = { version = "1", default-features = false }
 serde_json = { version = "1", default-features = false }
 syn = { version = "2", default-features = false, features = ["printing"] }
+tempfile = { version = "3", default-features = false }
 test-helpers = { default-features = false, path = "./crates/test-helpers" }
 test-log = { version = "0.2", default-features = false }
 tokio = { version = "1", default-features = false }

--- a/crates/transport/Cargo.toml
+++ b/crates/transport/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wrpc-transport"
-version = "0.27.0"
+version = "0.27.1"
 description = "wRPC core transport functionality"
 
 authors.workspace = true

--- a/crates/transport/Cargo.toml
+++ b/crates/transport/Cargo.toml
@@ -20,6 +20,7 @@ io-std = ["tokio/io-std"]
 anyhow = { workspace = true, features = ["std"] }
 bytes = { workspace = true }
 futures = { workspace = true, features = ["std"] }
+pin-project-lite = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt", "time"] }
 tokio-stream = { workspace = true }
 tokio-util = { workspace = true, features = ["codec", "io"] }

--- a/crates/transport/src/frame/codec.rs
+++ b/crates/transport/src/frame/codec.rs
@@ -4,11 +4,7 @@ use bytes::{Bytes, BytesMut};
 use tracing::{instrument, trace};
 use wasm_tokio::{Leb128DecoderU32, Leb128DecoderU64, Leb128Encoder};
 
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct Frame {
-    pub path: Arc<[usize]>,
-    pub data: Bytes,
-}
+use super::{Frame, FrameRef};
 
 pub struct Decoder {
     path: Option<Vec<usize>>,
@@ -126,20 +122,6 @@ impl tokio_util::codec::Decoder for Decoder {
             path: Arc::from(path),
             data,
         }))
-    }
-}
-
-pub struct FrameRef<'a> {
-    pub path: &'a [usize],
-    pub data: &'a [u8],
-}
-
-impl<'a> From<&'a Frame> for FrameRef<'a> {
-    fn from(Frame { path, data }: &'a Frame) -> Self {
-        Self {
-            path: path.as_ref(),
-            data: data.as_ref(),
-        }
     }
 }
 

--- a/crates/transport/src/frame/conn/accept.rs
+++ b/crates/transport/src/frame/conn/accept.rs
@@ -1,0 +1,77 @@
+use core::future::Future;
+use core::ops::{Deref, DerefMut};
+
+use tokio::io::{AsyncRead, AsyncWrite};
+
+pub trait Accept {
+    /// Transport-specific invocation context
+    type Context: Send + Sync + 'static;
+
+    /// Outgoing byte stream
+    type Outgoing: AsyncWrite + Send + Sync + Unpin + 'static;
+
+    /// Incoming byte stream
+    type Incoming: AsyncRead + Send + Sync + Unpin + 'static;
+
+    fn accept(
+        &self,
+    ) -> impl Future<Output = std::io::Result<(Self::Context, Self::Outgoing, Self::Incoming)>>;
+}
+
+pub struct AcceptMapContext<T, F> {
+    inner: T,
+    f: F,
+}
+
+impl<T, F> Deref for AcceptMapContext<T, F> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<T, F> DerefMut for AcceptMapContext<T, F> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+
+pub trait AcceptExt: Accept + Sized {
+    fn map_context<T, F: Fn(Self::Context) -> T>(self, f: F) -> AcceptMapContext<Self, F> {
+        AcceptMapContext { inner: self, f }
+    }
+}
+
+impl<T: Accept> AcceptExt for T {}
+
+impl<T, U, F> Accept for AcceptMapContext<T, F>
+where
+    T: Accept,
+    U: Send + Sync + 'static,
+    F: Fn(T::Context) -> U,
+{
+    type Context = U;
+    type Outgoing = T::Outgoing;
+    type Incoming = T::Incoming;
+
+    async fn accept(&self) -> std::io::Result<(Self::Context, Self::Outgoing, Self::Incoming)> {
+        (&self).accept().await
+    }
+}
+
+impl<T, U, F> Accept for &AcceptMapContext<T, F>
+where
+    T: Accept,
+    U: Send + Sync + 'static,
+    F: Fn(T::Context) -> U,
+{
+    type Context = U;
+    type Outgoing = T::Outgoing;
+    type Incoming = T::Incoming;
+
+    async fn accept(&self) -> std::io::Result<(Self::Context, Self::Outgoing, Self::Incoming)> {
+        let (cx, tx, rx) = self.inner.accept().await?;
+        Ok(((self.f)(cx), tx, rx))
+    }
+}

--- a/crates/transport/src/frame/conn/client.rs
+++ b/crates/transport/src/frame/conn/client.rs
@@ -1,0 +1,87 @@
+use std::sync::Arc;
+
+use anyhow::Context as _;
+use bytes::{BufMut as _, Bytes, BytesMut};
+use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt as _};
+use tokio::sync::mpsc;
+use tokio::task::JoinSet;
+use tokio_stream::wrappers::ReceiverStream;
+use tokio_util::codec::Encoder;
+use tokio_util::io::StreamReader;
+use tokio_util::sync::PollSender;
+use tracing::{debug, error, instrument, trace, Instrument as _};
+use wasm_tokio::{CoreNameEncoder, CoreVecEncoderBytes};
+
+use crate::frame::conn::{egress, ingress, Incoming, Outgoing};
+use crate::frame::PROTOCOL;
+
+#[instrument(level = "trace", skip_all)]
+pub async fn invoke<P, I, O>(
+    mut tx: O,
+    rx: I,
+    instance: &str,
+    func: &str,
+    params: Bytes,
+    paths: impl AsRef<[P]> + Send,
+) -> anyhow::Result<(Outgoing, Incoming)>
+where
+    P: AsRef<[Option<usize>]> + Send + Sync,
+    I: AsyncRead + Unpin + Send + 'static,
+    O: AsyncWrite + Unpin + Send + 'static,
+{
+    let mut buf = BytesMut::with_capacity(
+        17_usize // len(PROTOCOL) + len(instance) + len(func) + len([]) + len(params)
+            .saturating_add(instance.len())
+            .saturating_add(func.len())
+            .saturating_add(params.len()),
+    );
+    buf.put_u8(PROTOCOL);
+    CoreNameEncoder.encode(instance, &mut buf)?;
+    CoreNameEncoder.encode(func, &mut buf)?;
+    buf.put_u8(0);
+    CoreVecEncoderBytes.encode(params, &mut buf)?;
+    trace!(?buf, "writing invocation");
+    tx.write_all(&buf)
+        .await
+        .context("failed to initialize connection")?;
+
+    let index = Arc::new(std::sync::Mutex::new(paths.as_ref().iter().collect()));
+    let (results_tx, results_rx) = mpsc::channel(1);
+    let mut results_io = JoinSet::new();
+    results_io.spawn({
+        let index = Arc::clone(&index);
+        async move {
+            if let Err(err) = ingress(rx, index, results_tx).await {
+                error!(?err, "result ingress failed")
+            } else {
+                debug!("result ingress successfully complete")
+            }
+        }
+        .in_current_span()
+    });
+
+    let (params_tx, params_rx) = mpsc::channel(1);
+    tokio::spawn(
+        async {
+            if let Err(err) = egress(params_rx, tx).await {
+                error!(?err, "parameter egress failed")
+            } else {
+                debug!("parameter egress successfully complete")
+            }
+        }
+        .in_current_span(),
+    );
+    Ok((
+        Outgoing {
+            tx: PollSender::new(params_tx),
+            path: Arc::from([]),
+            path_buf: Bytes::from_static(&[0]),
+        },
+        Incoming {
+            rx: Some(StreamReader::new(ReceiverStream::new(results_rx))),
+            path: Arc::from([]),
+            index,
+            io: Arc::new(results_io),
+        },
+    ))
+}

--- a/crates/transport/src/frame/conn/mod.rs
+++ b/crates/transport/src/frame/conn/mod.rs
@@ -1,0 +1,476 @@
+use core::mem;
+use core::pin::Pin;
+use core::task::{ready, Context, Poll};
+
+use std::sync::Arc;
+
+use anyhow::ensure;
+use bytes::{Buf as _, BufMut as _, Bytes, BytesMut};
+use futures::Sink as _;
+use pin_project_lite::pin_project;
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt as _};
+use tokio::sync::mpsc;
+use tokio::task::JoinSet;
+use tokio_stream::wrappers::ReceiverStream;
+use tokio_util::codec::Encoder;
+use tokio_util::io::StreamReader;
+use tokio_util::sync::PollSender;
+use tracing::{instrument, trace};
+use wasm_tokio::{AsyncReadLeb128 as _, Leb128Encoder};
+
+use crate::Index;
+
+mod accept;
+mod client;
+mod server;
+
+pub use accept::*;
+pub use client::*;
+pub use server::*;
+
+#[derive(Default)]
+pub enum IndexTrie {
+    #[default]
+    Empty,
+    Leaf {
+        tx: mpsc::Sender<std::io::Result<Bytes>>,
+        rx: Option<mpsc::Receiver<std::io::Result<Bytes>>>,
+    },
+    IndexNode {
+        tx: Option<mpsc::Sender<std::io::Result<Bytes>>>,
+        rx: Option<mpsc::Receiver<std::io::Result<Bytes>>>,
+        nested: Vec<Option<IndexTrie>>,
+    },
+    // TODO: Add partially-indexed `WildcardIndexNode`
+    WildcardNode {
+        tx: Option<mpsc::Sender<std::io::Result<Bytes>>>,
+        rx: Option<mpsc::Receiver<std::io::Result<Bytes>>>,
+        nested: Option<Box<IndexTrie>>,
+    },
+}
+
+impl<'a>
+    From<(
+        &'a [Option<usize>],
+        mpsc::Sender<std::io::Result<Bytes>>,
+        Option<mpsc::Receiver<std::io::Result<Bytes>>>,
+    )> for IndexTrie
+{
+    fn from(
+        (path, tx, rx): (
+            &'a [Option<usize>],
+            mpsc::Sender<std::io::Result<Bytes>>,
+            Option<mpsc::Receiver<std::io::Result<Bytes>>>,
+        ),
+    ) -> Self {
+        match path {
+            [] => Self::Leaf { tx, rx },
+            [None, path @ ..] => Self::WildcardNode {
+                tx: None,
+                rx: None,
+                nested: Some(Box::new(Self::from((path, tx, rx)))),
+            },
+            [Some(i), path @ ..] => Self::IndexNode {
+                tx: None,
+                rx: None,
+                nested: {
+                    let n = i.saturating_add(1);
+                    let mut nested = Vec::with_capacity(n);
+                    nested.resize_with(n, Option::default);
+                    nested[*i] = Some(Self::from((path, tx, rx)));
+                    nested
+                },
+            },
+        }
+    }
+}
+
+impl<'a>
+    From<(
+        &'a [Option<usize>],
+        mpsc::Sender<std::io::Result<Bytes>>,
+        mpsc::Receiver<std::io::Result<Bytes>>,
+    )> for IndexTrie
+{
+    fn from(
+        (path, tx, rx): (
+            &'a [Option<usize>],
+            mpsc::Sender<std::io::Result<Bytes>>,
+            mpsc::Receiver<std::io::Result<Bytes>>,
+        ),
+    ) -> Self {
+        Self::from((path, tx, Some(rx)))
+    }
+}
+
+impl<'a> From<(&'a [Option<usize>], mpsc::Sender<std::io::Result<Bytes>>)> for IndexTrie {
+    fn from((path, tx): (&'a [Option<usize>], mpsc::Sender<std::io::Result<Bytes>>)) -> Self {
+        Self::from((path, tx, None))
+    }
+}
+
+impl<P: AsRef<[Option<usize>]>> FromIterator<P> for IndexTrie {
+    fn from_iter<T: IntoIterator<Item = P>>(iter: T) -> Self {
+        let mut root = Self::Empty;
+        for path in iter {
+            let (tx, rx) = mpsc::channel(16);
+            if !root.insert(path.as_ref(), tx, Some(rx)) {
+                return Self::Empty;
+            }
+        }
+        root
+    }
+}
+
+impl IndexTrie {
+    #[instrument(level = "trace", skip(self), ret(level = "trace"))]
+    fn take_rx(&mut self, path: &[usize]) -> Option<mpsc::Receiver<std::io::Result<Bytes>>> {
+        let Some((i, path)) = path.split_first() else {
+            return match self {
+                Self::Empty => None,
+                Self::Leaf { rx, .. } => rx.take(),
+                Self::IndexNode { tx, rx, nested } => {
+                    let rx = rx.take();
+                    if nested.is_empty() && tx.is_none() {
+                        *self = Self::Empty;
+                    }
+                    rx
+                }
+                Self::WildcardNode { tx, rx, nested } => {
+                    let rx = rx.take();
+                    if nested.is_none() && tx.is_none() {
+                        *self = Self::Empty;
+                    }
+                    rx
+                }
+            };
+        };
+        match self {
+            Self::Empty | Self::Leaf { .. } | Self::WildcardNode { .. } => None,
+            Self::IndexNode { ref mut nested, .. } => nested
+                .get_mut(*i)
+                .and_then(|nested| nested.as_mut().and_then(|nested| nested.take_rx(path))),
+            // TODO: Demux the subscription
+            //Self::WildcardNode { ref mut nested, .. } => {
+            //    nested.as_mut().and_then(|nested| nested.take(path))
+            //}
+        }
+    }
+
+    #[instrument(level = "trace", skip(self), ret(level = "trace"))]
+    fn get_tx(&mut self, path: &[usize]) -> Option<mpsc::Sender<std::io::Result<Bytes>>> {
+        let Some((i, path)) = path.split_first() else {
+            return match self {
+                Self::Empty => None,
+                Self::Leaf { tx, .. } => Some(tx.clone()),
+                Self::IndexNode { tx, .. } | Self::WildcardNode { tx, .. } => tx.clone(),
+            };
+        };
+        match self {
+            Self::Empty | Self::Leaf { .. } | Self::WildcardNode { .. } => None,
+            Self::IndexNode { ref mut nested, .. } => {
+                let nested = nested.get_mut(*i)?;
+                let nested = nested.as_mut()?;
+                nested.get_tx(path)
+            } // TODO: Demux the subscription
+              //Self::WildcardNode { ref mut nested, .. } => {
+              //    nested.as_mut().and_then(|nested| nested.take(path))
+              //}
+        }
+    }
+
+    /// Inserts `sender` and `receiver` under a `path` - returns `false` if it failed and `true` if it succeeded.
+    /// Tree state after `false` is returned is undefined
+    #[instrument(level = "trace", skip(self, sender, receiver), ret(level = "trace"))]
+    fn insert(
+        &mut self,
+        path: &[Option<usize>],
+        sender: mpsc::Sender<std::io::Result<Bytes>>,
+        receiver: Option<mpsc::Receiver<std::io::Result<Bytes>>>,
+    ) -> bool {
+        match self {
+            Self::Empty => {
+                *self = Self::from((path, sender, receiver));
+                true
+            }
+            Self::Leaf { .. } => {
+                let Some((i, path)) = path.split_first() else {
+                    return false;
+                };
+                let Self::Leaf { tx, rx } = mem::take(self) else {
+                    return false;
+                };
+                if let Some(i) = i {
+                    let n = i.saturating_add(1);
+                    let mut nested = Vec::with_capacity(n);
+                    nested.resize_with(n, Option::default);
+                    nested[*i] = Some(Self::from((path, sender, receiver)));
+                    *self = Self::IndexNode {
+                        tx: Some(tx),
+                        rx,
+                        nested,
+                    };
+                } else {
+                    *self = Self::WildcardNode {
+                        tx: Some(tx),
+                        rx,
+                        nested: Some(Box::new(Self::from((path, sender, receiver)))),
+                    };
+                }
+                true
+            }
+            Self::IndexNode {
+                ref mut tx,
+                ref mut rx,
+                ref mut nested,
+            } => match (&tx, &rx, path) {
+                (None, None, []) => {
+                    *tx = Some(sender);
+                    *rx = receiver;
+                    true
+                }
+                (_, _, [Some(i), path @ ..]) => {
+                    let cap = i.saturating_add(1);
+                    if nested.len() < cap {
+                        nested.resize_with(cap, Option::default);
+                    }
+                    let nested = &mut nested[*i];
+                    if let Some(nested) = nested {
+                        nested.insert(path, sender, receiver)
+                    } else {
+                        *nested = Some(Self::from((path, sender, receiver)));
+                        true
+                    }
+                }
+                _ => false,
+            },
+            Self::WildcardNode {
+                ref mut tx,
+                ref mut rx,
+                ref mut nested,
+            } => match (&tx, &rx, path) {
+                (None, None, []) => {
+                    *tx = Some(sender);
+                    *rx = receiver;
+                    true
+                }
+                (_, _, [None, path @ ..]) => {
+                    if let Some(nested) = nested {
+                        nested.insert(path, sender, receiver)
+                    } else {
+                        *nested = Some(Box::new(Self::from((path, sender, receiver))));
+                        true
+                    }
+                }
+                _ => false,
+            },
+        }
+    }
+}
+
+pin_project! {
+    #[project = IncomingProj]
+    pub struct Incoming {
+        #[pin]
+        rx: Option<StreamReader<ReceiverStream<std::io::Result<Bytes>>, Bytes>>,
+        path: Arc<[usize]>,
+        index: Arc<std::sync::Mutex<IndexTrie>>,
+        io: Arc<JoinSet<()>>,
+    }
+}
+
+impl Index<Self> for Incoming {
+    #[instrument(level = "trace", skip(self), fields(path = ?self.path))]
+    fn index(&self, path: &[usize]) -> anyhow::Result<Self> {
+        ensure!(!path.is_empty());
+        let path = if self.path.is_empty() {
+            Arc::from(path)
+        } else {
+            Arc::from([self.path.as_ref(), path].concat())
+        };
+        trace!("locking index trie");
+        let mut index = self
+            .index
+            .lock()
+            .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err.to_string()))?;
+        trace!(?path, "taking index subscription");
+        let rx = index
+            .take_rx(&path)
+            .map(|rx| StreamReader::new(ReceiverStream::new(rx)));
+        Ok(Self {
+            rx,
+            path,
+            index: Arc::clone(&self.index),
+            io: Arc::clone(&self.io),
+        })
+    }
+}
+
+impl AsyncRead for Incoming {
+    #[instrument(level = "trace", skip_all, fields(path = ?self.path), ret(level = "trace"))]
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        if buf.remaining() == 0 {
+            return Poll::Ready(Ok(()));
+        }
+        trace!("reading");
+        let this = self.as_mut().project();
+        let Some(rx) = this.rx.as_pin_mut() else {
+            trace!("reader is closed");
+            return Poll::Ready(Ok(()));
+        };
+        ready!(rx.poll_read(cx, buf))?;
+        trace!(?buf, "read buffer");
+        if buf.filled().is_empty() {
+            self.rx.take();
+        }
+        Poll::Ready(Ok(()))
+    }
+}
+
+pin_project! {
+    #[project = OutgoingProj]
+    pub struct Outgoing {
+        #[pin]
+        tx: PollSender<(Bytes, Bytes)>,
+        path: Arc<[usize]>,
+        path_buf: Bytes,
+    }
+}
+
+impl Index<Self> for Outgoing {
+    #[instrument(level = "trace", skip(self), fields(path = ?self.path))]
+    fn index(&self, path: &[usize]) -> anyhow::Result<Self> {
+        ensure!(!path.is_empty());
+        let path: Arc<[usize]> = if self.path.is_empty() {
+            Arc::from(path)
+        } else {
+            Arc::from([self.path.as_ref(), path].concat())
+        };
+        let mut buf = BytesMut::with_capacity(path.len().saturating_add(5));
+        let n = u32::try_from(path.len())
+            .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidInput, err))?;
+        trace!(n, "encoding path length");
+        Leb128Encoder.encode(n, &mut buf)?;
+        for p in path.as_ref() {
+            let p = u32::try_from(*p)
+                .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidInput, err))?;
+            trace!(p, "encoding path element");
+            Leb128Encoder.encode(p, &mut buf)?;
+        }
+        Ok(Self {
+            tx: self.tx.clone(),
+            path,
+            path_buf: buf.freeze(),
+        })
+    }
+}
+
+impl AsyncWrite for Outgoing {
+    #[instrument(level = "trace", skip_all, fields(path = ?self.path, buf = format!("{buf:02x?}")), ret(level = "trace"))]
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<std::io::Result<usize>> {
+        trace!("writing outgoing chunk");
+        let mut this = self.project();
+        ready!(this.tx.as_mut().poll_ready(cx))
+            .map_err(|err| std::io::Error::new(std::io::ErrorKind::BrokenPipe, err))?;
+        this.tx
+            .start_send((this.path_buf.clone(), Bytes::copy_from_slice(buf)))
+            .map_err(|err| std::io::Error::new(std::io::ErrorKind::BrokenPipe, err))?;
+        Poll::Ready(Ok(buf.len()))
+    }
+
+    #[instrument(level = "trace", skip_all, fields(path = ?self.path), ret(level = "trace"))]
+    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        Poll::Ready(Ok(()))
+    }
+
+    #[instrument(level = "trace", skip_all, fields(path = ?self.path), ret(level = "trace"))]
+    fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        Poll::Ready(Ok(()))
+    }
+}
+
+#[instrument(level = "trace", skip_all, ret(level = "trace"))]
+async fn ingress(
+    mut rx: impl AsyncRead + Unpin,
+    index: Arc<std::sync::Mutex<IndexTrie>>,
+    param_tx: mpsc::Sender<std::io::Result<Bytes>>,
+) -> std::io::Result<()> {
+    loop {
+        trace!("reading path length");
+        let b = match rx.read_u8().await {
+            Ok(b) => b,
+            Err(err) if err.kind() == std::io::ErrorKind::UnexpectedEof => return Ok(()),
+            Err(err) => return Err(err),
+        };
+        let n = AsyncReadExt::chain([b].as_slice(), &mut rx)
+            .read_u32_leb128()
+            .await?;
+        let n = n
+            .try_into()
+            .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidInput, err))?;
+        trace!(n, "read path length");
+        let tx = if n == 0 {
+            &param_tx
+        } else {
+            let mut path = Vec::with_capacity(n);
+            for i in 0..n {
+                trace!(i, "reading path element");
+                let p = rx.read_u32_leb128().await?;
+                let p = usize::try_from(p)
+                    .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidInput, err))?;
+                path.push(p);
+            }
+            trace!(?path, "read path");
+
+            trace!("locking index trie");
+            let mut index = index
+                .lock()
+                .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err.to_string()))?;
+            &index.get_tx(&path).ok_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    format!("`{path:?}` subscription not found"),
+                )
+            })?
+        };
+        trace!("reading data length");
+        let n = rx.read_u32_leb128().await?;
+        let n = n
+            .try_into()
+            .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidInput, err))?;
+        trace!(n, "read data length");
+        let mut buf = BytesMut::with_capacity(n);
+        buf.put_bytes(0, n);
+        rx.read_exact(&mut buf).await?;
+        tx.send(Ok(buf.freeze())).await.map_err(|_| {
+            std::io::Error::new(std::io::ErrorKind::BrokenPipe, "stream receiver closed")
+        })?;
+    }
+}
+
+#[instrument(level = "trace", skip_all, ret(level = "trace"))]
+async fn egress(
+    mut rx: mpsc::Receiver<(Bytes, Bytes)>,
+    mut tx: impl AsyncWrite + Unpin,
+) -> std::io::Result<()> {
+    let mut buf = BytesMut::with_capacity(5);
+    trace!("waiting for next frame");
+    while let Some((path, data)) = rx.recv().await {
+        let data_len = u32::try_from(data.len())
+            .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidInput, err))?;
+        buf.clear();
+        Leb128Encoder.encode(data_len, &mut buf)?;
+        let mut frame = path.chain(&mut buf).chain(data);
+        trace!(?frame, "writing egress frame");
+        tx.write_all_buf(&mut frame).await?;
+    }
+    Ok(())
+}

--- a/crates/transport/src/frame/conn/server.rs
+++ b/crates/transport/src/frame/conn/server.rs
@@ -1,0 +1,186 @@
+use core::fmt::{Debug, Display};
+
+use std::collections::{hash_map, HashMap};
+use std::sync::Arc;
+
+use anyhow::bail;
+use bytes::Bytes;
+use futures::{Stream, StreamExt as _};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite};
+use tokio::sync::{mpsc, Mutex};
+use tokio::task::JoinSet;
+use tokio_stream::wrappers::ReceiverStream;
+use tokio_util::io::StreamReader;
+use tokio_util::sync::PollSender;
+use tracing::{debug, error, instrument, trace, Instrument as _, Span};
+use wasm_tokio::AsyncReadCore as _;
+
+use crate::frame::conn::{egress, ingress, Accept};
+use crate::frame::{Incoming, Outgoing};
+use crate::Serve;
+
+pub struct Server<C, I, O>(Mutex<HashMap<String, HashMap<String, mpsc::Sender<(C, I, O)>>>>);
+
+impl<C, I, O> Default for Server<C, I, O> {
+    fn default() -> Self {
+        Self(Mutex::default())
+    }
+}
+
+pub enum AcceptError<C, I, O> {
+    IO(std::io::Error),
+    UnsupportedVersion(u8),
+    UnhandledFunction { instance: String, name: String },
+    Send(mpsc::error::SendError<(C, I, O)>),
+}
+
+impl<C, I, O> Debug for AcceptError<C, I, O> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AcceptError::IO(err) => Debug::fmt(err, f),
+            AcceptError::UnsupportedVersion(v) => write!(f, "unsupported version byte: {v}"),
+            AcceptError::UnhandledFunction { instance, name } => {
+                write!(f, "`{instance}#{name}` does not have a handler registered")
+            }
+            AcceptError::Send(err) => Debug::fmt(err, f),
+        }
+    }
+}
+
+impl<C, I, O> Display for AcceptError<C, I, O> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AcceptError::IO(err) => Display::fmt(err, f),
+            AcceptError::UnsupportedVersion(v) => write!(f, "unsupported version byte: {v}"),
+            AcceptError::UnhandledFunction { instance, name } => {
+                write!(f, "`{instance}#{name}` does not have a handler registered")
+            }
+            AcceptError::Send(err) => Display::fmt(err, f),
+        }
+    }
+}
+
+impl<C, I, O> std::error::Error for AcceptError<C, I, O> {}
+
+impl<C, I, O> Server<C, I, O>
+where
+    I: AsyncRead + Unpin,
+{
+    /// Accept a connection on a [TcpListener].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if accepting the connection has failed
+    #[instrument(level = "trace", skip_all, ret(level = "trace"))]
+    pub async fn accept(
+        &self,
+        listener: impl Accept<Context = C, Incoming = I, Outgoing = O>,
+    ) -> Result<(), AcceptError<C, I, O>> {
+        let (cx, tx, mut rx) = listener.accept().await.map_err(AcceptError::IO)?;
+        let mut instance = String::default();
+        let mut name = String::default();
+        match rx.read_u8().await.map_err(AcceptError::IO)? {
+            0x00 => {
+                rx.read_core_name(&mut instance)
+                    .await
+                    .map_err(AcceptError::IO)?;
+                rx.read_core_name(&mut name)
+                    .await
+                    .map_err(AcceptError::IO)?;
+            }
+            v => return Err(AcceptError::UnsupportedVersion(v)),
+        }
+        let h = self.0.lock().await;
+        let h = h
+            .get(&instance)
+            .and_then(|h| h.get(&name))
+            .ok_or_else(|| AcceptError::UnhandledFunction { instance, name })?;
+        h.send((cx, rx, tx)).await.map_err(AcceptError::Send)?;
+        Ok(())
+    }
+}
+
+impl<C, I, O> Serve for Server<C, I, O>
+where
+    C: Send + Sync + 'static,
+    I: AsyncRead + Send + Sync + Unpin + 'static,
+    O: AsyncWrite + Send + Sync + Unpin + 'static,
+{
+    type Context = C;
+    type Outgoing = Outgoing;
+    type Incoming = Incoming;
+
+    #[instrument(level = "trace", skip(self, paths))]
+    async fn serve(
+        &self,
+        instance: &str,
+        func: &str,
+        paths: impl Into<Arc<[Box<[Option<usize>]>]>> + Send,
+    ) -> anyhow::Result<
+        impl Stream<Item = anyhow::Result<(Self::Context, Self::Outgoing, Self::Incoming)>> + 'static,
+    > {
+        let (tx, rx) = mpsc::channel(1024);
+        let mut handlers = self.0.lock().await;
+        match handlers
+            .entry(instance.to_string())
+            .or_default()
+            .entry(func.to_string())
+        {
+            hash_map::Entry::Occupied(_) => {
+                bail!("handler for `{instance}#{func}` already exists")
+            }
+            hash_map::Entry::Vacant(entry) => {
+                entry.insert(tx);
+            }
+        }
+        let paths = paths.into();
+        let span = Span::current();
+        Ok(ReceiverStream::new(rx).then(move |(cx, rx, tx)| {
+            let _span = span.enter();
+            trace!("received invocation");
+            let index = Arc::new(std::sync::Mutex::new(paths.as_ref().iter().collect()));
+            async move {
+                let (params_tx, params_rx) = mpsc::channel(1);
+                let mut params_io = JoinSet::new();
+                params_io.spawn({
+                    let index = Arc::clone(&index);
+                    async move {
+                        if let Err(err) = ingress(rx, index, params_tx).await {
+                            error!(?err, "parameter ingress failed")
+                        } else {
+                            debug!("parameter ingress successfully complete")
+                        }
+                    }
+                    .in_current_span()
+                });
+
+                let (results_tx, results_rx) = mpsc::channel(1);
+                tokio::spawn(
+                    async {
+                        if let Err(err) = egress(results_rx, tx).await {
+                            error!(?err, "result egress failed")
+                        } else {
+                            debug!("result egress successfully complete")
+                        }
+                    }
+                    .in_current_span(),
+                );
+                Ok((
+                    cx,
+                    Outgoing {
+                        tx: PollSender::new(results_tx),
+                        path: Arc::from([]),
+                        path_buf: Bytes::from_static(&[0]),
+                    },
+                    Incoming {
+                        rx: Some(StreamReader::new(ReceiverStream::new(params_rx))),
+                        path: Arc::from([]),
+                        index,
+                        io: Arc::new(params_io),
+                    },
+                ))
+            }
+            .instrument(span.clone())
+        }))
+    }
+}

--- a/crates/transport/src/frame/mod.rs
+++ b/crates/transport/src/frame/mod.rs
@@ -1,0 +1,34 @@
+use std::sync::Arc;
+
+use bytes::Bytes;
+
+mod codec;
+mod conn;
+pub mod tcp;
+#[cfg(unix)]
+pub mod unix;
+
+pub use codec::*;
+pub use conn::*;
+
+pub const PROTOCOL: u8 = 0;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Frame {
+    pub path: Arc<[usize]>,
+    pub data: Bytes,
+}
+
+pub struct FrameRef<'a> {
+    pub path: &'a [usize],
+    pub data: &'a [u8],
+}
+
+impl<'a> From<&'a Frame> for FrameRef<'a> {
+    fn from(Frame { path, data }: &'a Frame) -> Self {
+        Self {
+            path: path.as_ref(),
+            data: data.as_ref(),
+        }
+    }
+}

--- a/crates/transport/src/frame/tcp.rs
+++ b/crates/transport/src/frame/tcp.rs
@@ -1,0 +1,95 @@
+use core::net::SocketAddr;
+
+use anyhow::{bail, Context as _};
+use bytes::Bytes;
+use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};
+use tokio::net::{TcpListener, TcpStream, ToSocketAddrs};
+use tracing::instrument;
+
+use crate::frame::{invoke, Accept, Incoming, Outgoing};
+use crate::Invoke;
+
+pub struct Invocation(std::sync::Mutex<Option<TcpStream>>);
+
+pub struct Client<P>(P);
+
+impl<T> From<T> for Client<T>
+where
+    T: ToSocketAddrs + Clone,
+{
+    fn from(path: T) -> Self {
+        Self(path)
+    }
+}
+
+impl From<TcpStream> for Invocation {
+    fn from(stream: TcpStream) -> Self {
+        Self(std::sync::Mutex::new(Some(stream)))
+    }
+}
+
+impl<T> Invoke for Client<T>
+where
+    T: ToSocketAddrs + Clone + Send + Sync,
+{
+    type Context = ();
+    type Outgoing = Outgoing;
+    type Incoming = Incoming;
+
+    #[instrument(level = "trace", skip(self, paths, params), fields(params = format!("{params:02x?}")))]
+    async fn invoke<P>(
+        &self,
+        (): Self::Context,
+        instance: &str,
+        func: &str,
+        params: Bytes,
+        paths: impl AsRef<[P]> + Send,
+    ) -> anyhow::Result<(Self::Outgoing, Self::Incoming)>
+    where
+        P: AsRef<[Option<usize>]> + Send + Sync,
+    {
+        let stream = TcpStream::connect(self.0.clone()).await?;
+        let (rx, tx) = stream.into_split();
+        invoke(tx, rx, instance, func, params, paths).await
+    }
+}
+
+impl Invoke for Invocation {
+    type Context = ();
+    type Outgoing = Outgoing;
+    type Incoming = Incoming;
+
+    #[instrument(level = "trace", skip(self, paths, params), fields(params = format!("{params:02x?}")))]
+    async fn invoke<P>(
+        &self,
+        (): Self::Context,
+        instance: &str,
+        func: &str,
+        params: Bytes,
+        paths: impl AsRef<[P]> + Send,
+    ) -> anyhow::Result<(Self::Outgoing, Self::Incoming)>
+    where
+        P: AsRef<[Option<usize>]> + Send + Sync,
+    {
+        let stream = match self.0.lock() {
+            Ok(mut stream) => stream
+                .take()
+                .context("stream was already used for an invocation")?,
+            Err(_) => bail!("stream lock poisoned"),
+        };
+        let (rx, tx) = stream.into_split();
+        invoke(tx, rx, instance, func, params, paths).await
+    }
+}
+
+impl Accept for TcpListener {
+    type Context = SocketAddr;
+    type Outgoing = OwnedWriteHalf;
+    type Incoming = OwnedReadHalf;
+
+    async fn accept(&self) -> std::io::Result<(Self::Context, Self::Outgoing, Self::Incoming)> {
+        let (stream, addr) = self.accept().await?;
+        let (rx, tx) = stream.into_split();
+        Ok((addr, tx, rx))
+    }
+}

--- a/crates/transport/src/frame/unix.rs
+++ b/crates/transport/src/frame/unix.rs
@@ -1,0 +1,179 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::{bail, Context as _};
+use bytes::Bytes;
+use tokio::net::unix::{OwnedReadHalf, OwnedWriteHalf, SocketAddr};
+use tokio::net::{UnixListener, UnixStream};
+use tracing::instrument;
+
+use crate::frame::{invoke, Accept, Incoming, Outgoing};
+use crate::Invoke;
+
+pub struct Invocation(std::sync::Mutex<Option<UnixStream>>);
+
+pub struct Client<P>(P);
+
+impl From<PathBuf> for Client<PathBuf> {
+    fn from(path: PathBuf) -> Self {
+        Self(path)
+    }
+}
+
+impl<'a> From<&'a Path> for Client<&'a Path> {
+    fn from(path: &'a Path) -> Self {
+        Self(path)
+    }
+}
+
+impl<'a> From<&'a std::os::unix::net::SocketAddr> for Client<&'a std::os::unix::net::SocketAddr> {
+    fn from(addr: &'a std::os::unix::net::SocketAddr) -> Self {
+        Self(addr)
+    }
+}
+
+impl From<std::os::unix::net::SocketAddr> for Client<std::os::unix::net::SocketAddr> {
+    fn from(addr: std::os::unix::net::SocketAddr) -> Self {
+        Self(addr)
+    }
+}
+
+impl Invoke for Client<PathBuf> {
+    type Context = ();
+    type Outgoing = Outgoing;
+    type Incoming = Incoming;
+
+    #[instrument(level = "trace", skip(self, paths, params), fields(params = format!("{params:02x?}")))]
+    async fn invoke<P>(
+        &self,
+        (): Self::Context,
+        instance: &str,
+        func: &str,
+        params: Bytes,
+        paths: impl AsRef<[P]> + Send,
+    ) -> anyhow::Result<(Self::Outgoing, Self::Incoming)>
+    where
+        P: AsRef<[Option<usize>]> + Send + Sync,
+    {
+        let stream = UnixStream::connect(&self.0).await?;
+        let (rx, tx) = stream.into_split();
+        invoke(tx, rx, instance, func, params, paths).await
+    }
+}
+
+impl Invoke for Client<&Path> {
+    type Context = ();
+    type Outgoing = Outgoing;
+    type Incoming = Incoming;
+
+    #[instrument(level = "trace", skip(self, paths, params), fields(params = format!("{params:02x?}")))]
+    async fn invoke<P>(
+        &self,
+        (): Self::Context,
+        instance: &str,
+        func: &str,
+        params: Bytes,
+        paths: impl AsRef<[P]> + Send,
+    ) -> anyhow::Result<(Self::Outgoing, Self::Incoming)>
+    where
+        P: AsRef<[Option<usize>]> + Send + Sync,
+    {
+        let stream = UnixStream::connect(self.0).await?;
+        let (rx, tx) = stream.into_split();
+        invoke(tx, rx, instance, func, params, paths).await
+    }
+}
+
+impl Invoke for Client<&std::os::unix::net::SocketAddr> {
+    type Context = ();
+    type Outgoing = Outgoing;
+    type Incoming = Incoming;
+
+    #[instrument(level = "trace", skip(self, paths, params), fields(params = format!("{params:02x?}")))]
+    async fn invoke<P>(
+        &self,
+        (): Self::Context,
+        instance: &str,
+        func: &str,
+        params: Bytes,
+        paths: impl AsRef<[P]> + Send,
+    ) -> anyhow::Result<(Self::Outgoing, Self::Incoming)>
+    where
+        P: AsRef<[Option<usize>]> + Send + Sync,
+    {
+        let stream = std::os::unix::net::UnixStream::connect_addr(self.0)?;
+        let stream = UnixStream::from_std(stream)?;
+        let (rx, tx) = stream.into_split();
+        invoke(tx, rx, instance, func, params, paths).await
+    }
+}
+
+impl Invoke for Client<std::os::unix::net::SocketAddr> {
+    type Context = ();
+    type Outgoing = Outgoing;
+    type Incoming = Incoming;
+
+    #[instrument(level = "trace", skip(self, paths, params), fields(params = format!("{params:02x?}")))]
+    async fn invoke<P>(
+        &self,
+        (): Self::Context,
+        instance: &str,
+        func: &str,
+        params: Bytes,
+        paths: impl AsRef<[P]> + Send,
+    ) -> anyhow::Result<(Self::Outgoing, Self::Incoming)>
+    where
+        P: AsRef<[Option<usize>]> + Send + Sync,
+    {
+        let stream = std::os::unix::net::UnixStream::connect_addr(&self.0)?;
+        let stream = UnixStream::from_std(stream)?;
+        let (rx, tx) = stream.into_split();
+        invoke(tx, rx, instance, func, params, paths).await
+    }
+}
+
+impl From<UnixStream> for Invocation {
+    fn from(stream: UnixStream) -> Self {
+        Self(std::sync::Mutex::new(Some(stream)))
+    }
+}
+
+impl Invoke for Invocation {
+    type Context = ();
+    type Outgoing = Outgoing;
+    type Incoming = Incoming;
+
+    #[instrument(level = "trace", skip(self, paths, params), fields(params = format!("{params:02x?}")))]
+    async fn invoke<P>(
+        &self,
+        (): Self::Context,
+        instance: &str,
+        func: &str,
+        params: Bytes,
+        paths: impl AsRef<[P]> + Send,
+    ) -> anyhow::Result<(Self::Outgoing, Self::Incoming)>
+    where
+        P: AsRef<[Option<usize>]> + Send + Sync,
+    {
+        let stream = match self.0.lock() {
+            Ok(mut stream) => stream
+                .take()
+                .context("stream was already used for an invocation")?,
+            Err(_) => bail!("stream lock poisoned"),
+        };
+        let (rx, tx) = stream.into_split();
+        invoke(tx, rx, instance, func, params, paths).await
+    }
+}
+
+impl Accept for UnixListener {
+    type Context = SocketAddr;
+    type Outgoing = OwnedWriteHalf;
+    type Incoming = OwnedReadHalf;
+
+    #[instrument(level = "trace")]
+    async fn accept(&self) -> std::io::Result<(Self::Context, Self::Outgoing, Self::Incoming)> {
+        let (stream, addr) = self.accept().await?;
+        let (rx, tx) = stream.into_split();
+        Ok((addr, tx, rx))
+    }
+}


### PR DESCRIPTION
Implement a framed transport providing multiplexing to simple byte streams.

Include TCP and Unix socket implementations built on top of the same abstraction

Closes #9 

- [x] async/indexing support
- [x] ~windows named pipe support~ I think this best belongs in a separate PR. TCP can already be used on all platforms