### PR TITLE
fix(transport): discard async data if receiver is closed

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,6 @@
     "https://nixify.cachix.org"
     "https://crane.cachix.org"
     "https://nix-community.cachix.org"
-    "https://cache.garnix.io"
   ];
   nixConfig.extra-trusted-public-keys = [
     "bytecodealliance.cachix.org-1:0SBgh//n2n0heh0sDFhTm+ZKBRy2sInakzFGfzN531Y="
@@ -13,7 +12,6 @@
     "nixify.cachix.org-1:95SiUQuf8Ij0hwDweALJsLtnMyv/otZamWNRp1Q1pXw="
     "crane.cachix.org-1:8Scfpmn9w+hGdXH/Q9tTLiYAE/2dnJYRJP7kl80GuRk="
     "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
-    "cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g="
   ];
 
   inputs.nixify.inputs.nixlib.follows = "nixlib";


### PR DESCRIPTION
If the receiver is closed, then the data, even though received, can never reach the other end. Simply discard it and log at debug