### PR TITLE
fix(nats): prevent I/O task from being dropped prematurely

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4143,7 +4143,7 @@ dependencies = [
 
 [[package]]
 name = "wrpc-transport-nats"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "anyhow",
  "async-nats 0.36.0",

--- a/crates/transport-nats/Cargo.toml
+++ b/crates/transport-nats/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wrpc-transport-nats"
-version = "0.27.0"
+version = "0.27.1"
 description = "wRPC NATS transport"
 
 authors.workspace = true


### PR DESCRIPTION
Keep the I/O task around for as long as subscribers and writers are in use