### PR TITLE
feat(webtransport): rework with `wtransport`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,6 +130,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
 
 [[package]]
+name = "asn1-rs"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-nats"
 version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -146,7 +185,7 @@ dependencies = [
  "rand",
  "regex",
  "ring",
- "rustls-native-certs",
+ "rustls-native-certs 0.7.3",
  "rustls-pemfile",
  "rustls-webpki",
  "serde",
@@ -180,7 +219,7 @@ dependencies = [
  "rand",
  "regex",
  "ring",
- "rustls-native-certs",
+ "rustls-native-certs 0.7.3",
  "rustls-pemfile",
  "rustls-webpki",
  "serde",
@@ -792,6 +831,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "der-parser"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
 name = "deranged"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -830,6 +883,17 @@ dependencies = [
  "libc",
  "redox_users",
  "winapi",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1117,7 +1181,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http 0.2.12",
+ "http",
  "indexmap",
  "slab",
  "tokio",
@@ -1262,10 +1326,10 @@ dependencies = [
  "tokio",
  "tracing-subscriber",
  "url",
- "web-transport-quinn",
  "wit-bindgen-wrpc",
  "wrpc-transport",
  "wrpc-transport-web",
+ "wtransport",
 ]
 
 [[package]]
@@ -1281,10 +1345,10 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "web-transport-quinn",
  "wit-bindgen-wrpc",
  "wrpc-transport",
  "wrpc-transport-web",
+ "wtransport",
 ]
 
 [[package]]
@@ -1300,21 +1364,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
+name = "httlib-huffman"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a9fcbcc408c5526c3ab80d534e5c86e7967c1fb7aa0a8c76abd1edc27deb877"
+
+[[package]]
 name = "http"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
 dependencies = [
  "bytes",
  "fnv",
@@ -1328,7 +1387,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http 0.2.12",
+ "http",
  "pin-project-lite",
 ]
 
@@ -1361,7 +1420,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http 0.2.12",
+ "http",
  "http-body",
  "httparse",
  "httpdate",
@@ -1628,6 +1687,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1661,6 +1726,16 @@ dependencies = [
  "log",
  "rand",
  "signatory",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -1729,6 +1804,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "octets"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "109983a091271ee8916076731ba5fdc9ee22fea871bc7c6ceab9bfd423eb1d99"
+
+[[package]]
+name = "oid-registry"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
+dependencies = [
+ "asn1-rs",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1757,6 +1847,16 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pem"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e459365e590736a54c3fa561947c84837534b8e9af6fc5bf781307e82658fae"
+dependencies = [
+ "base64 0.22.1",
+ "serde",
+]
 
 [[package]]
 name = "pem-rfc7468"
@@ -2005,6 +2105,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54077e1872c46788540de1ea3d7f4ccb1983d12f9aa909b234468676c1a36779"
 dependencies = [
+ "pem",
  "ring",
  "rustls-pki-types",
  "time",
@@ -2099,7 +2200,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http 0.2.12",
+ "http",
  "http-body",
  "hyper",
  "ipnet",
@@ -2174,6 +2275,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2217,6 +2327,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcaf18a4f2be7326cd874a5fa579fae794320a0f388d365dca7e480e55f83f8a"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pemfile"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2243,7 +2366,7 @@ dependencies = [
  "log",
  "once_cell",
  "rustls",
- "rustls-native-certs",
+ "rustls-native-certs 0.7.3",
  "rustls-platform-verifier-android",
  "rustls-webpki",
  "security-framework",
@@ -2596,6 +2719,17 @@ name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "synstructure"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "system-configuration"
@@ -3645,36 +3779,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "web-transport-proto"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a3806ea43df5817f0d90618c842d28db5946bc18a5db0659b2275c2be48d472"
-dependencies = [
- "bytes",
- "http 1.1.0",
- "thiserror",
- "url",
-]
-
-[[package]]
-name = "web-transport-quinn"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3020b51cda10472a365e42d9a701916d4f04d74cc743de08246ef6a421c2d137"
-dependencies = [
- "bytes",
- "futures",
- "http 1.1.0",
- "log",
- "quinn",
- "quinn-proto",
- "thiserror",
- "tokio",
- "url",
- "web-transport-proto",
-]
-
-[[package]]
 name = "webpki-roots"
 version = "0.26.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4193,10 +4297,9 @@ dependencies = [
  "rustls",
  "tokio",
  "tracing",
- "url",
- "web-transport-quinn",
  "wrpc-cli",
  "wrpc-transport",
+ "wtransport",
 ]
 
 [[package]]
@@ -4257,12 +4360,13 @@ dependencies = [
  "anyhow",
  "bytes",
  "futures",
+ "quinn",
  "test-log",
  "tokio",
  "tracing",
- "web-transport-quinn",
  "wrpc-test",
  "wrpc-transport",
+ "wtransport",
 ]
 
 [[package]]
@@ -4308,6 +4412,60 @@ dependencies = [
  "wrpc-runtime-wasmtime",
  "wrpc-transport",
  "wrpc-transport-nats",
+]
+
+[[package]]
+name = "wtransport"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db854cf8d3a1089a8a4e283dace6afc3746d4e570e82392779a53c943cf7aa4"
+dependencies = [
+ "bytes",
+ "pem",
+ "quinn",
+ "rcgen",
+ "rustls",
+ "rustls-native-certs 0.8.0",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "sha2",
+ "socket2",
+ "thiserror",
+ "time",
+ "tokio",
+ "tracing",
+ "url",
+ "wtransport-proto",
+ "x509-parser",
+]
+
+[[package]]
+name = "wtransport-proto"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28b252f224a6467fb0dfc38be040bc1dde17ba5bae43120c536225ff6f4f60b"
+dependencies = [
+ "httlib-huffman",
+ "octets",
+ "thiserror",
+ "url",
+]
+
+[[package]]
+name = "x509-parser"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "rusticata-macros",
+ "thiserror",
+ "time",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,10 +248,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
+name = "axum"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "504e3947307ac8326a5437504c517c4b56716c9d98fac0028c2acc7ca47d70ae"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.5.0",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper 1.0.1",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper 1.0.1",
+ "tower-layer",
+ "tower-service",
+]
 
 [[package]]
 name = "backtrace"
@@ -1181,7 +1237,26 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.12",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.1.0",
  "indexmap",
  "slab",
  "tokio",
@@ -1381,15 +1456,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.12",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http 1.1.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-range-header"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08a397c49fec283e3d6211adbe480be95aae5f304cfb923e9970e08956d5168a"
 
 [[package]]
 name = "httparse"
@@ -1419,9 +1534,9 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -1431,6 +1546,42 @@ dependencies = [
  "tower-service",
  "tracing",
  "want",
+]
+
+[[package]]
+name = "hyper"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbff0a806a4728c99295b254c8838933b5b082d75e3cb70c8dab21fdfbcfa9a"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "h2 0.4.6",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "hyper 1.5.0",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -1660,6 +1811,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
 name = "maybe-owned"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1685,6 +1842,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "minimal-lexical"
@@ -2199,10 +2366,10 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
- "hyper",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.31",
  "ipnet",
  "js-sys",
  "log",
@@ -2213,7 +2380,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 0.1.2",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2391,6 +2558,12 @@ dependencies = [
  "rustls-pki-types",
  "untrusted",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
 
 [[package]]
 name = "ryu"
@@ -2721,6 +2894,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
+
+[[package]]
 name = "synstructure"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3013,6 +3192,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2873938d487c3cfb9aed7546dc9f2711d867c9f90c46b889989a2cb84eba6b4f"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper 0.1.2",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8437150ab6bbc8c5f0f519e3d5ed4aa883a83dd4cdd3d1b21f9482936046cb97"
+dependencies = [
+ "bitflags 2.6.0",
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "http-range-header",
+ "httpdate",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
 name = "tower-service"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3102,6 +3327,12 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "unicase"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e51b68083f157f853b6379db119d1c1be0e6e4dec98101079dec41f6f5cf6df"
 
 [[package]]
 name = "unicode-bidi"
@@ -3766,6 +3997,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bc3cf014fb336883a411cd662f987abf6a1d2a27f2f0008616a0070bbf6bd0d"
 dependencies = [
  "wast",
+]
+
+[[package]]
+name = "web-rust-keyvalue-tcp"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "axum",
+ "clap",
+ "futures",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tracing",
+ "tracing-subscriber",
+ "wit-bindgen-wrpc",
+ "wrpc-transport",
+ "wrpc-transport-web",
+ "wrpc-wasi-keyvalue",
+ "wrpc-wasi-keyvalue-mem",
+ "wtransport",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,12 @@ license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wrpc"
 
 [workspace]
-members = ["benches/reactor", "crates/*", "examples/rust/*"]
+members = [
+    "benches/reactor",
+    "crates/*",
+    "examples/rust/*",
+    "examples/web/rust",
+]
 
 [features]
 default = ["bin", "nats", "net", "quic", "wasmtime", "web-transport"]
@@ -116,6 +121,7 @@ wrpc-transport = { workspace = true, features = ["net"] }
 [workspace.dependencies]
 anyhow = { version = "1", default-features = false }
 async-nats = { version = "0.37", default-features = false }
+axum = { version = "0.7", default-features = false }
 bitflags = { version = "2", default-features = false }
 bytes = { version = "1", default-features = false }
 clap = { version = "4", default-features = false }
@@ -142,6 +148,8 @@ test-log = { version = "0.2", default-features = false }
 tokio = { version = "1", default-features = false }
 tokio-stream = { version = "0.1", default-features = false }
 tokio-util = { version = "0.7", default-features = false }
+tower = { version = "0.5", default-features = false }
+tower-http = { version = "0.6", default-features = false }
 tracing = { version = "0.1", default-features = false }
 tracing-subscriber = { version = "0.3", default-features = false }
 url = { version = "2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,8 +36,8 @@ bin-wasmtime = ["dep:tokio", "dep:wrpc-wasmtime-cli", "tokio/rt-multi-thread"]
 nats = ["dep:async-nats", "dep:wrpc-transport-nats", "wrpc-cli/nats"]
 net = ["wrpc-transport/net"]
 quic = ["dep:wrpc-transport-quic"]
-web-transport = ["dep:wrpc-transport-web"]
 wasmtime = ["dep:wrpc-runtime-wasmtime"]
+web-transport = ["dep:wrpc-transport-web"]
 
 [[bin]]
 name = "wit-bindgen-wrpc"
@@ -153,7 +153,6 @@ wasmparser = { version = "0.219", default-features = false }
 wasmtime = { version = "25", default-features = false }
 wasmtime-cli-flags = { version = "25", default-features = false }
 wasmtime-wasi = { version = "25", default-features = false }
-web-transport-quinn = { version = "0.3.4", default-features = false }
 wit-bindgen = { version = "0.34", default-features = false }
 wit-bindgen-core = { version = "0.34", default-features = false }
 wit-bindgen-wrpc = { version = "0.8", default-features = false, path = "./crates/wit-bindgen" }
@@ -173,3 +172,4 @@ wrpc-transport-web = { version = "0.1", path = "./crates/transport-web", default
 wrpc-wasi-keyvalue = { version = "0.1", path = "./crates/wasi-keyvalue", default-features = false }
 wrpc-wasi-keyvalue-mem = { version = "0.1", path = "./crates/wasi-keyvalue-mem", default-features = false }
 wrpc-wasmtime-cli = { version = "0.2", path = "./crates/wasmtime-cli", default-features = false }
+wtransport = { version = "0.4", default-features = false }

--- a/crates/test/Cargo.toml
+++ b/crates/test/Cargo.toml
@@ -15,30 +15,22 @@ default = ["nats", "quic", "web-transport"]
 nats = ["dep:async-nats", "async-nats/ring", "wrpc-cli/nats"]
 quic = [
     "dep:quinn",
-    "dep:rcgen",
-    "dep:rustls",
     "quinn/log",
     "quinn/platform-verifier",
     "quinn/ring",
     "quinn/runtime-tokio",
     "quinn/rustls",
-    "rcgen/crypto",
-    "rcgen/ring",
-    "rcgen/zeroize",
-    "rustls/logging",
-    "rustls/ring",
 ]
-web-transport = ["dep:web-transport-quinn", "dep:url", "quic"]
+web-transport = ["dep:wtransport", "wtransport/self-signed"]
 
 [dependencies]
 anyhow = { workspace = true }
 async-nats = { workspace = true, optional = true }
 quinn = { workspace = true, optional = true }
-rcgen = { workspace = true, optional = true }
-rustls = { workspace = true, optional = true }
+rcgen = { workspace = true, features = ["crypto", "ring", "zeroize"] }
+rustls = { workspace = true, features = ["logging", "ring"] }
 tokio = { workspace = true, features = ["net", "process", "rt-multi-thread"] }
 tracing = { workspace = true }
-url = { workspace = true, optional = true }
-web-transport-quinn = { workspace = true, optional = true }
 wrpc-cli = { workspace = true }
 wrpc-transport = { workspace = true }
+wtransport = { workspace = true, optional = true }

--- a/crates/transport-web/Cargo.toml
+++ b/crates/transport-web/Cargo.toml
@@ -12,9 +12,10 @@ repository.workspace = true
 [dependencies]
 anyhow = { workspace = true, features = ["std"] }
 bytes = { workspace = true }
+quinn = { workspace = true }
 tracing = { workspace = true }
-web-transport-quinn = { workspace = true }
 wrpc-transport = { workspace = true }
+wtransport = { workspace = true, features = ["quinn"] }
 
 [dev-dependencies]
 futures = { workspace = true }

--- a/crates/transport-web/tests/loopback.rs
+++ b/crates/transport-web/tests/loopback.rs
@@ -85,7 +85,7 @@ async fn loopback() -> anyhow::Result<()> {
                 anyhow::Ok(())
             },
             async {
-                srv.accept(srv_conn)
+                srv.accept(&srv_conn)
                     .await
                     .context("failed to accept invocation")?;
                 let ((), mut outgoing, mut incoming) = invocations
@@ -161,6 +161,8 @@ async fn loopback() -> anyhow::Result<()> {
                 Ok(())
             }
         )?;
+        _ = clt;
+        _ = srv;
         Ok(())
     })
     .await

--- a/crates/transport/src/frame/conn/mod.rs
+++ b/crates/transport/src/frame/conn/mod.rs
@@ -351,7 +351,7 @@ impl AsyncRead for Incoming {
             return Poll::Ready(Ok(()));
         };
         ready!(rx.poll_read(cx, buf))?;
-        trace!(?buf, "read buffer");
+        trace!(buf = ?buf.filled(), "read buffer");
         if buf.filled().is_empty() {
             self.rx.take();
         }
@@ -478,7 +478,9 @@ async fn ingress(
         trace!(n, "read data length");
         let mut buf = BytesMut::with_capacity(n);
         buf.put_bytes(0, n);
+        trace!("reading data");
         rx.read_exact(&mut buf).await?;
+        trace!(?buf, "read data");
         tx.send(Ok(buf.freeze())).await.map_err(|_| {
             std::io::Error::new(std::io::ErrorKind::BrokenPipe, "stream receiver closed")
         })?;

--- a/crates/transport/src/serve.rs
+++ b/crates/transport/src/serve.rs
@@ -75,9 +75,9 @@ pub trait ServeExt: Serve {
         <Results::Encoder as tokio_util::codec::Encoder<Results>>::Error:
             std::error::Error + Send + Sync + 'static,
     {
+        let span = Span::current();
         async {
             let invocations = self.serve(instance, func, paths).await?;
-            let span = Span::current();
             Ok(invocations.and_then(move |(cx, outgoing, incoming)| {
                 async {
                     let mut dec = FramedRead::new(incoming, Params::Decoder::default());

--- a/examples/rust/hello-tcp-server/src/main.rs
+++ b/examples/rust/hello-tcp-server/src/main.rs
@@ -1,5 +1,6 @@
 use core::net::SocketAddr;
 use core::pin::pin;
+
 use std::sync::Arc;
 
 use anyhow::Context as _;

--- a/examples/rust/hello-web-client/Cargo.toml
+++ b/examples/rust/hello-web-client/Cargo.toml
@@ -24,7 +24,7 @@ rustls = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 tracing-subscriber = { workspace = true, features = ["ansi", "fmt"] }
 url = { workspace = true }
-web-transport-quinn = { workspace = true }
 wit-bindgen-wrpc = { workspace = true }
 wrpc-transport = { workspace = true, features = ["net"] }
 wrpc-transport-web = { workspace = true }
+wtransport = { workspace = true }

--- a/examples/rust/hello-web-server/Cargo.toml
+++ b/examples/rust/hello-web-server/Cargo.toml
@@ -26,7 +26,7 @@ rustls = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "signal", "net"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["ansi", "fmt"] }
-web-transport-quinn = { workspace = true }
 wit-bindgen-wrpc = { workspace = true }
 wrpc-transport = { workspace = true }
 wrpc-transport-web = { workspace = true }
+wtransport = { workspace = true }

--- a/examples/rust/hello-web-server/src/main.rs
+++ b/examples/rust/hello-web-server/src/main.rs
@@ -46,8 +46,12 @@ async fn main() -> anyhow::Result<()> {
 
     let Args { addr } = Args::parse();
 
-    let CertifiedKey { cert, key_pair } = generate_simple_self_signed(["localhost".to_string()])
-        .context("failed to generate server certificate")?;
+    let CertifiedKey { cert, key_pair } = generate_simple_self_signed([
+        "localhost".to_string(),
+        "::1".to_string(),
+        "127.0.0.1".to_string(),
+    ])
+    .context("failed to generate server certificate")?;
     let cert = CertificateDer::from(cert);
 
     let conf = rustls::ServerConfig::builder_with_protocol_versions(&[&TLS13])

--- a/examples/web/rust/Cargo.toml
+++ b/examples/web/rust/Cargo.toml
@@ -1,0 +1,46 @@
+[package]
+name = "web-rust-keyvalue-tcp"
+version = "0.1.0"
+
+authors.workspace = true
+categories.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+anyhow = { workspace = true }
+axum = { workspace = true, features = ["tokio", "http1", "http2"] }
+clap = { workspace = true, features = [
+    "color",
+    "derive",
+    "error-context",
+    "help",
+    "std",
+    "suggestions",
+    "usage",
+] }
+futures = { workspace = true }
+tokio = { workspace = true, features = [
+    "macros",
+    "rt-multi-thread",
+    "signal",
+    "net",
+] }
+tower = { workspace = true }
+tower-http = { workspace = true, features = ["fs", "trace"] }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true, features = [
+    "ansi",
+    "env-filter",
+    "fmt",
+    "smallvec",
+    "tracing-log",
+] }
+wit-bindgen-wrpc = { workspace = true }
+wrpc-transport = { workspace = true }
+wrpc-transport-web = { workspace = true }
+wrpc-wasi-keyvalue = { workspace = true }
+wrpc-wasi-keyvalue-mem = { workspace = true }
+wtransport = { workspace = true, features = ["self-signed"] }

--- a/examples/web/rust/index.html
+++ b/examples/web/rust/index.html
@@ -1,0 +1,125 @@
+<!doctype html>
+<html>
+  <title>wRPC WebTransport demo</title>
+  <head>
+    <meta content="text/html;charset=utf-8" http-equiv="Content-Type"/>
+  </head>
+  <body>
+    <script type="module">
+      import { CERT_DIGEST, PORT } from './consts.js';
+
+      async function run() {
+        console.log('connecting to wRPC over WebTransport on `' + PORT +'`...');
+        try {
+          var transport = new WebTransport("https://localhost:" + PORT, {
+            serverCertificateHashes: [
+                {
+                  algorithm: "sha-256",
+                  value: CERT_DIGEST.buffer
+                }
+            ]
+          });
+        } catch (e) {
+          console.log('failed to connect: ' + e);
+          return;
+        }
+
+        console.log('waiting for readiness...');
+        try {
+          await transport.ready;
+        } catch (e) {
+          console.log('failed to await readiness: ' + e);
+          return;
+        }
+
+        console.log('creating `open` stream...');
+        let stream = await transport.createBidirectionalStream();
+
+        console.log('writing invocation...');
+        let tx = stream.writable.getWriter();
+        let rx = stream.readable.getReader();
+        await tx.write(new Uint8Array([0]));
+        await tx.write(new Uint8Array(["wasi:keyvalue/store@0.2.0-draft2".length]));
+        await tx.write(new TextEncoder().encode("wasi:keyvalue/store@0.2.0-draft2"));
+        await tx.write(new Uint8Array(["open".length]));
+        await tx.write(new TextEncoder().encode("open"));
+        await tx.write(new Uint8Array([0]));
+        await tx.write(new Uint8Array([1 + "test".length]));
+        await tx.write(new Uint8Array(["test".length]));
+        await tx.write(new TextEncoder().encode("test"));
+        tx.close();
+
+        console.log('reading `open` response...');
+        let data = await rx.read();
+        console.log('received `open` response: '+ data.value);
+        let res = data.value[2];
+        if (res != 0) {
+            console.log("failed to open bucket")
+            return;
+        }
+        let bucket = data.value.slice(3);
+        console.log('opened bucket: '+ bucket);
+
+        console.log('creating `set` stream...');
+        stream = await transport.createBidirectionalStream();
+        tx = stream.writable.getWriter();
+        rx = stream.readable.getReader();
+        await tx.write(new Uint8Array([0]));
+        await tx.write(new Uint8Array(["wasi:keyvalue/store@0.2.0-draft2".length]));
+        await tx.write(new TextEncoder().encode("wasi:keyvalue/store@0.2.0-draft2"));
+        await tx.write(new Uint8Array(["bucket.set".length]));
+        await tx.write(new TextEncoder().encode("bucket.set"));
+        await tx.write(new Uint8Array([0]));
+        await tx.write(new Uint8Array([bucket.length + 1 + "foo".length + 1 + "bar".length]));
+        await tx.write(bucket);
+        await tx.write(new Uint8Array(["foo".length]));
+        await tx.write(new TextEncoder().encode("foo"));
+        await tx.write(new Uint8Array(["bar".length]));
+        await tx.write(new TextEncoder().encode("bar"));
+        tx.close();
+
+        console.log('reading `set` response...');
+        data = await rx.read();
+        console.log('received `set` response: '+ data.value);
+        res = data.value[2];
+        if (res != 0) {
+            console.log("failed to set `foo` to `bar`")
+            return;
+        }
+
+        console.log('creating `get` stream...');
+        stream = await transport.createBidirectionalStream();
+        tx = stream.writable.getWriter();
+        rx = stream.readable.getReader();
+        await tx.write(new Uint8Array([0]));
+        await tx.write(new Uint8Array(["wasi:keyvalue/store@0.2.0-draft2".length]));
+        await tx.write(new TextEncoder().encode("wasi:keyvalue/store@0.2.0-draft2"));
+        await tx.write(new Uint8Array(["bucket.get".length]));
+        await tx.write(new TextEncoder().encode("bucket.get"));
+        await tx.write(new Uint8Array([0]));
+        await tx.write(new Uint8Array([bucket.length + 1 + "foo".length]));
+        await tx.write(bucket);
+        await tx.write(new Uint8Array(["foo".length]));
+        await tx.write(new TextEncoder().encode("foo"));
+        tx.close();
+
+        console.log('reading `get` response...');
+        data = await rx.read();
+        console.log('received `get` response: '+ data.value);
+        res = data.value[2];
+        if (res != 0) {
+            console.log("failed to get `foo` value")
+            return;
+        }
+        let ok = data.value[3];
+        if (ok != 1) {
+            console.log("`foo` key missing")
+            return;
+        }
+        let value = new TextDecoder().decode(data.value.slice(5));
+        console.log('got `foo` value: '+ value);
+      }
+      run();
+    </script>
+  </body>
+</html>

--- a/examples/web/rust/src/main.rs
+++ b/examples/web/rust/src/main.rs
@@ -1,0 +1,206 @@
+use core::net::SocketAddr;
+use core::pin::pin;
+use core::time::Duration;
+
+use std::sync::Arc;
+
+use anyhow::Context as _;
+use axum::http::header::CONTENT_TYPE;
+use axum::response::Html;
+use axum::routing::get;
+use axum::Router;
+use clap::Parser;
+use futures::stream::select_all;
+use futures::StreamExt as _;
+use tokio::task::JoinSet;
+use tokio::{select, signal};
+use tower_http::trace::TraceLayer;
+use tracing::{debug, error, info, trace, warn};
+use tracing_subscriber::layer::SubscriberExt as _;
+use tracing_subscriber::util::SubscriberInitExt as _;
+use wtransport::tls::Sha256DigestFmt;
+use wtransport::{Endpoint, Identity, ServerConfig};
+
+//#[derive(Clone, Copy)]
+//struct Handler;
+//
+//impl bindings::exports::wrpc_examples::hello::handler::Handler<()> for Handler {
+//    async fn hello(&self, (): ()) -> anyhow::Result<String> {
+//        Ok("hello from Rust".to_string())
+//    }
+//}
+
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    /// Address to serve web interface on
+    #[arg(default_value = "[::1]:8080")]
+    addr: SocketAddr,
+}
+
+#[must_use]
+pub fn env_filter() -> tracing_subscriber::EnvFilter {
+    tracing_subscriber::EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"))
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::fmt::layer().compact().without_time())
+        .with(env_filter())
+        .init();
+
+    let Args { addr } = Args::parse();
+
+    let lis = tokio::net::TcpListener::bind(&addr)
+        .await
+        .with_context(|| format!("failed to bind TCP listener on `{addr}`"))?;
+
+    let id = Identity::self_signed(["localhost", "127.0.0.1", "::1"])
+        .context("failed to generate server certificate")?;
+    let digest = id.certificate_chain().as_slice()[0]
+        .hash()
+        .fmt(Sha256DigestFmt::BytesArray);
+
+    let ep = Endpoint::server(
+        ServerConfig::builder()
+            .with_bind_default(0)
+            .with_identity(id)
+            .keep_alive_interval(Some(Duration::from_secs(3)))
+            .build(),
+    )
+    .context("failed to create server endpoint")?;
+    let ep_addr = ep
+        .local_addr()
+        .context("failed to query WebTransport socket address")?;
+    let port = ep_addr.port();
+
+    let index = get(Html(include_str!("../index.html")));
+    let http = axum::serve(
+        lis,
+        Router::new()
+            .route("/", index.clone())
+            .route(
+                "/consts.js",
+                get((
+                    [(CONTENT_TYPE, "application/javascript")],
+                    format!(
+                        r#"
+export const CERT_DIGEST = new Uint8Array({digest});
+export const PORT = "{port}"
+"#
+                    ),
+                )),
+            )
+            .fallback(index)
+            .layer(TraceLayer::new_for_http()),
+    );
+
+    let srv = Arc::new(wrpc_transport_web::Server::new());
+    let webt = tokio::spawn({
+        let mut tasks = JoinSet::<anyhow::Result<()>>::new();
+        let srv = Arc::clone(&srv);
+        async move {
+            loop {
+                select! {
+                    conn = ep.accept() => {
+                        let srv = Arc::clone(&srv);
+                        tasks.spawn(async move {
+                            let req = conn
+                                .await
+                                .context("failed to accept WebTransport connection")?;
+                            let conn = req
+                                .accept()
+                                .await
+                                .context("failed to establish WebTransport connection")?;
+                            let wrpc = wrpc_transport_web::Client::from(conn);
+                            loop {
+                                srv.accept(&wrpc)
+                                    .await
+                                    .context("failed to accept wRPC connection")?;
+                            }
+                        });
+                    }
+                    Some(res) = tasks.join_next() => {
+                        match res {
+                            Ok(Ok(())) => {}
+                            Ok(Err(err)) => {
+                                warn!(?err, "failed to serve connection")
+                            }
+                            Err(err) => {
+                                error!(?err, "failed to join task")
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    });
+
+    let invocations = wrpc_wasi_keyvalue::exports::wasi::keyvalue::store::serve_interface(
+        srv.as_ref(),
+        wrpc_wasi_keyvalue_mem::Handler::default(),
+    )
+    .await
+    .context("failed to serve `wasi:keyvalue`")?;
+    let mut invocations = select_all(
+        invocations
+            .into_iter()
+            .map(|(instance, name, invocations)| invocations.map(move |res| (instance, name, res))),
+    );
+    let wrpc = tokio::spawn(async move {
+        let mut tasks = JoinSet::new();
+        loop {
+            select! {
+                Some((instance, name, res)) = invocations.next() => {
+                    match res {
+                        Ok(fut) => {
+                            debug!(instance, name, "invocation accepted");
+                            tasks.spawn(async move {
+                                if let Err(err) = fut.await {
+                                    warn!(?err, "failed to handle invocation");
+                                } else {
+                                    info!(instance, name, "invocation successfully handled");
+                                }
+                            });
+                        }
+                        Err(err) => {
+                            warn!(?err, instance, name, "failed to accept invocation");
+                        }
+                    }
+                }
+                Some(res) = tasks.join_next() => {
+                    if let Err(err) = res {
+                        error!(?err, "failed to join task")
+                    }
+                }
+                else => {
+                    return
+                }
+            }
+        }
+    });
+
+    let shutdown = signal::ctrl_c();
+    let mut shutdown = pin!(shutdown);
+    select! {
+        res = http => {
+            trace!("HTTP serving task stopped");
+            res.context("failed to serve HTTP")?;
+        }
+        res = webt => {
+            trace!("WebTransport serving task stopped");
+            res.context("failed to serve WebTransport")?;
+        }
+        res = wrpc => {
+            trace!("wRPC serving task stopped");
+            res.context("failed to serve wRPC invocations")?;
+        }
+        res = &mut shutdown => {
+            trace!("^C received");
+            res.context("failed to listen for ^C")?;
+        }
+    }
+    Ok(())
+}


### PR DESCRIPTION
`wtransport` seems to be better maintained and easier to get started with
added a begging of a very simple in-browser demo