### PR TITLE
fix(nats): block on publish in fallback runtime

### DIFF
--- a/crates/transport-nats/src/lib.rs
+++ b/crates/transport-nats/src/lib.rs
@@ -34,9 +34,7 @@ fn spawn_async(fut: impl Future<Output = ()> + Send + 'static) {
             rt.spawn(fut);
         }
         Err(_) => match tokio::runtime::Runtime::new() {
-            Ok(rt) => {
-                rt.spawn(fut);
-            }
+            Ok(rt) => rt.block_on(fut),
             Err(err) => error!(?err, "failed to create a new Tokio runtime"),
         },
     }


### PR DESCRIPTION
`spawn_async` created an ephemeral runtime, called `rt.spawn(fut)`, then let `rt` go out of scope on the next line — dropping the runtime cancelled the spawned task before it could run, so `Subscriber` / `SubjectWriter` `Drop` impls invoked from a non-tokio thread silently lost their unsubscribe / shutdown publishes. This intermittently hung `rust_dynamic_nats` in CI when its `thread::spawn(|| inv)` triggered the fallback path: the client awaited a stream-shutdown marker that was never sent.

`block_on` keeps the runtime alive for the duration of the future, which is what we want when the caller is on a non-tokio thread.