### PR TITLE
chore: remove `send-future`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2916,12 +2916,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "send-future"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224e328af6e080cddbab3c770b1cf50f0351ba0577091ef2410c3951d835ff87"
-
-[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5286,7 +5280,6 @@ dependencies = [
  "bytes",
  "futures",
  "pin-project-lite",
- "send-future",
  "test-log",
  "tokio",
  "tokio-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,7 +142,6 @@ redis = { version = "1.2", default-features = false }
 reqwest = { version = "0.13", default-features = false }
 rustls = { version = "0.23", default-features = false }
 semver = { version = "1", default-features = false }
-send-future = { version = "0.1", default-features = false }
 serde = { version = "1", default-features = false }
 serde_json = { version = "1", default-features = false }
 syn = { version = "2", default-features = false, features = ["printing"] }

--- a/crates/transport/Cargo.toml
+++ b/crates/transport/Cargo.toml
@@ -20,7 +20,6 @@ anyhow = { workspace = true, features = ["std"] }
 bytes = { workspace = true }
 futures = { workspace = true, features = ["std"] }
 pin-project-lite = { workspace = true }
-send-future = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt", "time"] }
 tokio-stream = { workspace = true }
 tokio-util = { workspace = true, features = ["codec", "io"] }

--- a/crates/transport/src/invoke.rs
+++ b/crates/transport/src/invoke.rs
@@ -27,44 +27,6 @@ pub trait Invoke: Send + Sync {
     type Incoming: AsyncRead + Index<Self::Incoming> + Send + Sync + Unpin + 'static;
 
     /// Invoke function `func` on instance `instance`
-    ///
-    /// Note, that compilation of code calling methods on [`Invoke`] implementations within [`Send`] async functions
-    /// may fail with hard-to-debug errors due to a compiler bug:
-    /// [https://github.com/rust-lang/rust/issues/96865](https://github.com/rust-lang/rust/issues/96865)
-    ///
-    /// The following fails to compile with rustc 1.78.0:
-    ///
-    /// ```compile_fail
-    /// use core::future::Future;
-    ///
-    /// fn invoke_send<T>() -> impl Future<Output = anyhow::Result<(T::Outgoing, T::Incoming)>> + Send
-    /// where
-    ///     T: wrpc_transport::Invoke<Context = ()> + Default,
-    /// {
-    ///     async { T::default().invoke((), "compiler-bug", "free", "since".into(), [[Some(2024)].as_slice(); 0]).await }
-    /// }
-    /// ```
-    ///
-    /// ```text
-    /// async { T::default().invoke((), "compiler-bug", "free", "since".into(), [[Some(2024)].as_slice(); 0]).await }
-    /// |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ implementation of `AsRef` is not general enough
-    ///  |
-    ///  = note: `[&'0 [Option<usize>]; 0]` must implement `AsRef<[&'1 [Option<usize>]]>`, for any two lifetimes `'0` and `'1`...
-    ///  = note: ...but it actually implements `AsRef<[&[Option<usize>]]>`
-    /// ```
-    ///
-    /// The fix is to call [`send`](send_future::SendFuture::send) provided by [`send_future::SendFuture`], re-exported by this crate, on the future before awaiting:
-    /// ```
-    /// use core::future::Future;
-    /// use wrpc_transport::SendFuture as _;
-    ///
-    /// fn invoke_send<T>() -> impl Future<Output = anyhow::Result<(T::Outgoing, T::Incoming)>> + Send
-    /// where
-    ///     T: wrpc_transport::Invoke<Context = ()> + Default,
-    /// {
-    ///     async { T::default().invoke((), "compiler-bug", "free", "since".into(), [[Some(2024)].as_slice(); 0]).send().await }
-    /// }
-    /// ```
     fn invoke<P>(
         &self,
         cx: Self::Context,
@@ -331,7 +293,6 @@ mod tests {
 
     use bytes::Bytes;
     use futures::{Stream, StreamExt as _};
-    use send_future::SendFuture as _;
 
     use super::*;
 
@@ -354,7 +315,6 @@ mod tests {
                     (),
                     [[None].as_slice()],
                 )
-                .send()
                 .await?;
             Ok(r0)
         }

--- a/crates/transport/src/lib.rs
+++ b/crates/transport/src/lib.rs
@@ -24,7 +24,6 @@ pub use frame::{
     Accept, Decoder as FrameDecoder, Encoder as FrameEncoder, Frame, FrameRef, Server,
 };
 pub use invoke::{Invoke, InvokeExt};
-pub use send_future::SendFuture;
 pub use serve::{Serve, ServeExt};
 pub use value::*;
 

--- a/crates/wit-bindgen-rust/src/interface.rs
+++ b/crates/wit-bindgen-rust/src/interface.rs
@@ -629,7 +629,7 @@ pub fn serve_interface<'a, T: {wrpc_transport}::Serve>(
                 self.src,
                 r#"
                 let wrpc__ = {anyhow}::Context::context(
-                    {wrpc_transport}::SendFuture::send({wrpc_transport}::InvokeExt::invoke_values_blocking(wrpc__, cx__, "{instance}", "{}", ({params}), "#,
+                    {wrpc_transport}::InvokeExt::invoke_values_blocking(wrpc__, cx__, "{instance}", "{}", ({params}), "#,
                 rpc_func_name(func),
                 wrpc_transport = self.gen.wrpc_transport_path(),
                 params = {
@@ -650,7 +650,7 @@ pub fn serve_interface<'a, T: {wrpc_transport}::Serve>(
                     self.src.push_str(".as_slice(), ");
                 }
             }
-            self.src.push_str("])).await,\n");
+            self.src.push_str("]).await,\n");
             uwriteln!(
                 self.src,
                 r#"
@@ -666,7 +666,7 @@ pub fn serve_interface<'a, T: {wrpc_transport}::Serve>(
                 self.src,
                 r#"
                 let (wrpc__, io__) = {anyhow}::Context::context(
-                    {wrpc_transport}::SendFuture::send({wrpc_transport}::InvokeExt::invoke_values(wrpc__, cx__, "{instance}", "{}", ({params}), "#,
+                    {wrpc_transport}::InvokeExt::invoke_values(wrpc__, cx__, "{instance}", "{}", ({params}), "#,
                 rpc_func_name(func),
                 wrpc_transport = self.gen.wrpc_transport_path(),
                 params = {
@@ -687,7 +687,7 @@ pub fn serve_interface<'a, T: {wrpc_transport}::Serve>(
                     self.src.push_str(".as_slice(), ");
                 }
             }
-            self.src.push_str("])).await,\n");
+            self.src.push_str("]).await,\n");
             uwriteln!(
                 self.src,
                 r#"


### PR DESCRIPTION
Looks like we're not hitting https://github.com/rust-lang/rust/issues/96865 anymore