### PR TITLE
[rust] Add streams WebTransport client and server examples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3187,6 +3187,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "streams-web-client"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "clap",
+ "futures",
+ "rustls",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "tracing-subscriber",
+ "url",
+ "wit-bindgen-wrpc",
+ "wrpc-transport",
+ "wrpc-transport-web",
+ "wtransport",
+]
+
+[[package]]
+name = "streams-web-server"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "clap",
+ "futures",
+ "rcgen",
+ "rustls",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "wit-bindgen-wrpc",
+ "wrpc-transport",
+ "wrpc-transport-web",
+ "wtransport",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/examples/rust/streams-web-client/Cargo.toml
+++ b/examples/rust/streams-web-client/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "streams-web-client"
+version = "0.1.0"
+
+authors.workspace = true
+categories.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+anyhow = { workspace = true, features = ["std"] }
+bytes = { workspace = true }
+clap = { workspace = true, features = [
+    "color",
+    "derive",
+    "error-context",
+    "help",
+    "std",
+    "suggestions",
+    "usage",
+] }
+futures = { workspace = true }
+rustls = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread"] }
+tokio-stream = { workspace = true, features = ["time"] }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true, features = [
+    "ansi",
+    "env-filter",
+    "fmt",
+] }
+url = { workspace = true }
+wit-bindgen-wrpc = { workspace = true }
+wrpc-transport = { workspace = true }
+wrpc-transport-web = { workspace = true }
+wtransport = { workspace = true }

--- a/examples/rust/streams-web-client/src/main.rs
+++ b/examples/rust/streams-web-client/src/main.rs
@@ -1,0 +1,143 @@
+use core::time::Duration;
+
+use std::sync::Arc;
+
+use anyhow::Context as _;
+use bytes::Bytes;
+use clap::Parser;
+use futures::{stream, StreamExt as _};
+use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
+use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
+use rustls::version::TLS13;
+use rustls::{DigitallySignedStruct, SignatureScheme};
+use tokio::{time, try_join};
+use tokio_stream::wrappers::IntervalStream;
+use tracing::debug;
+use url::Url;
+use wtransport::{ClientConfig, Endpoint};
+
+mod bindings {
+    wit_bindgen_wrpc::generate!({
+        with: {
+            "wrpc-examples:streams/handler": generate
+        }
+    });
+}
+
+use bindings::wrpc_examples::streams::handler::{echo, Req};
+
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    /// Address to invoke `wrpc-examples:streams/handler.echo` on
+    #[arg(default_value = "https://localhost:4433")]
+    addr: Url,
+}
+
+#[derive(Debug)]
+struct Insecure;
+
+impl ServerCertVerifier for Insecure {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &CertificateDer<'_>,
+        _intermediates: &[CertificateDer<'_>],
+        _server_name: &ServerName<'_>,
+        _ocsp_response: &[u8],
+        _now: UnixTime,
+    ) -> Result<ServerCertVerified, rustls::Error> {
+        Ok(ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer<'_>,
+        _dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        Ok(HandshakeSignatureValid::assertion())
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer<'_>,
+        _dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        Ok(HandshakeSignatureValid::assertion())
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        vec![SignatureScheme::ECDSA_NISTP256_SHA256]
+    }
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt().init();
+
+    let Args { addr } = Args::parse();
+
+    let conf = rustls::ClientConfig::builder_with_protocol_versions(&[&TLS13])
+        .dangerous()
+        .with_custom_certificate_verifier(Arc::new(Insecure))
+        .with_no_client_auth();
+
+    let ep = Endpoint::client(
+        ClientConfig::builder()
+            .with_bind_default()
+            .with_custom_tls(conf)
+            .build(),
+    )
+    .context("failed to create endpoint")?;
+
+    let session = ep
+        .connect(&addr)
+        .await
+        .context("failed to connect to server")?;
+    let wrpc = wrpc_transport_web::Client::from(session);
+
+    let numbers = Box::pin(
+        stream::iter(1..)
+            .take(10)
+            .zip(IntervalStream::new(time::interval(Duration::from_secs(1))))
+            .map(|(i, _)| i)
+            .ready_chunks(10),
+    );
+
+    // `stream<u8>` items are chunked using [`Bytes`]
+    let bytes = Box::pin(
+        stream::iter(b"foo bar baz")
+            .zip(IntervalStream::new(time::interval(Duration::from_secs(1))))
+            .map(|(i, _)| *i)
+            .ready_chunks(10)
+            .map(Bytes::from),
+    );
+
+    let (mut numbers, mut bytes, io) = echo(&wrpc, (), Req { numbers, bytes })
+        .await
+        .context("failed to invoke `wrpc-examples:streams/handler.echo`")?;
+    try_join!(
+        async {
+            if let Some(io) = io {
+                debug!("performing async I/O");
+                io.await.context("failed to complete async I/O")
+            } else {
+                Ok(())
+            }
+        },
+        async {
+            while let Some(item) = numbers.next().await {
+                eprintln!("numbers: {item:?}");
+            }
+            Ok(())
+        },
+        async {
+            while let Some(item) = bytes.next().await {
+                eprintln!("bytes: {item:?}");
+            }
+            Ok(())
+        }
+    )?;
+    Ok(())
+}

--- a/examples/rust/streams-web-client/wit/deps.lock
+++ b/examples/rust/streams-web-client/wit/deps.lock
@@ -1,0 +1,4 @@
+[streams]
+path = "../../../wit/streams"
+sha256 = "5064bee90ebea73f1695987191fbbfea71ed2dbb69839814009490b4fbe8e96f"
+sha512 = "dfca3844d91c6c8e83fefd7b9511a366b464cf69d017c61b671409cb26dc9490a0e59a8e60ef15b77fdeb4fc1b8d9e6efa11c2fb1a1dabd0141e5e6afe8a59b9"

--- a/examples/rust/streams-web-client/wit/deps.toml
+++ b/examples/rust/streams-web-client/wit/deps.toml
@@ -1,0 +1,1 @@
+streams = "../../../wit/streams"

--- a/examples/rust/streams-web-client/wit/deps/streams/streams.wit
+++ b/examples/rust/streams-web-client/wit/deps/streams/streams.wit
@@ -1,0 +1,17 @@
+package wrpc-examples:streams;
+
+interface handler {
+    record req {
+        numbers: stream<u64>,
+        bytes: stream<u8>,
+    }
+    echo: func(r: req) -> (numbers: stream<u64>, bytes: stream<u8>);
+}
+
+world client {
+    import handler;
+}
+
+world server {
+    export handler;
+}

--- a/examples/rust/streams-web-client/wit/world.wit
+++ b/examples/rust/streams-web-client/wit/world.wit
@@ -1,0 +1,5 @@
+package wrpc-examples:streams-rust-client;
+
+world client {
+    include wrpc-examples:streams/client;
+}

--- a/examples/rust/streams-web-server/Cargo.toml
+++ b/examples/rust/streams-web-server/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "streams-web-server"
+version = "0.1.0"
+
+authors.workspace = true
+categories.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+anyhow = { workspace = true, features = ["std"] }
+bytes = { workspace = true }
+clap = { workspace = true, features = [
+    "color",
+    "derive",
+    "error-context",
+    "help",
+    "std",
+    "suggestions",
+    "usage",
+] }
+futures = { workspace = true }
+rcgen = { workspace = true, features = ["crypto", "ring", "zeroize"] }
+rustls = { workspace = true }
+tokio = { workspace = true, features = ["net", "rt-multi-thread", "signal"] }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true, features = [
+    "ansi",
+    "env-filter",
+    "fmt",
+] }
+wit-bindgen-wrpc = { workspace = true }
+wrpc-transport = { workspace = true }
+wrpc-transport-web = { workspace = true }
+wtransport = { workspace = true }

--- a/examples/rust/streams-web-server/src/main.rs
+++ b/examples/rust/streams-web-server/src/main.rs
@@ -1,0 +1,170 @@
+use core::net::SocketAddr;
+use core::pin::{pin, Pin};
+
+use std::sync::Arc;
+
+use anyhow::Context as _;
+use bytes::Bytes;
+use clap::Parser;
+use futures::stream::select_all;
+use futures::{Stream, StreamExt as _};
+use rcgen::{generate_simple_self_signed, CertifiedKey};
+use rustls::pki_types::{CertificateDer, PrivatePkcs8KeyDer};
+use rustls::version::TLS13;
+use tokio::task::JoinSet;
+use tokio::{select, signal};
+use tracing::{debug, error, info, warn};
+use wtransport::{Endpoint, ServerConfig};
+
+mod bindings {
+    wit_bindgen_wrpc::generate!({
+        with: {
+            "wrpc-examples:streams/handler": generate,
+        }
+    });
+}
+
+use bindings::exports::wrpc_examples::streams::handler::Req;
+
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    /// Address to serve `wrpc-examples:streams/handler.echo` on
+    #[arg(default_value = "[::1]:4433")]
+    addr: SocketAddr,
+}
+
+#[derive(Clone, Copy)]
+struct Server;
+
+impl bindings::exports::wrpc_examples::streams::handler::Handler<()> for Server {
+    async fn echo(
+        &self,
+        _ctx: (),
+        Req { numbers, bytes }: Req,
+    ) -> anyhow::Result<(
+        Pin<Box<dyn Stream<Item = Vec<u64>> + Send>>,
+        Pin<Box<dyn Stream<Item = Bytes> + Send>>,
+    )> {
+        Ok((numbers, bytes))
+    }
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt().init();
+
+    let Args { addr } = Args::parse();
+
+    let CertifiedKey { cert, signing_key } = generate_simple_self_signed([
+        "localhost".to_string(),
+        "::1".to_string(),
+        "127.0.0.1".to_string(),
+    ])
+    .context("failed to generate server certificate")?;
+    let cert = CertificateDer::from(cert);
+
+    let conf = rustls::ServerConfig::builder_with_protocol_versions(&[&TLS13])
+        .with_no_client_auth()
+        .with_single_cert(
+            vec![cert],
+            PrivatePkcs8KeyDer::from(signing_key.serialize_der()).into(),
+        )
+        .context("failed to create server config")?;
+
+    let ep = Endpoint::server(
+        ServerConfig::builder()
+            .with_bind_address(addr)
+            .with_custom_tls(conf)
+            .build(),
+    )
+    .context("failed to create server endpoint")?;
+
+    let srv = Arc::new(wrpc_transport_web::Server::new());
+    let invocations = bindings::serve(srv.as_ref(), Server)
+        .await
+        .context("failed to serve `wrpc-examples:streams/handler.echo`")?;
+
+    let accept = tokio::spawn({
+        let mut tasks = JoinSet::<anyhow::Result<()>>::new();
+        let srv = Arc::clone(&srv);
+        async move {
+            loop {
+                select! {
+                    conn = ep.accept() => {
+                        let srv = Arc::clone(&srv);
+                        tasks.spawn(async move {
+                            let req = conn
+                                .await
+                                .context("failed to accept WebTransport connection")?;
+                            let conn = req
+                                .accept()
+                                .await
+                                .context("failed to establish WebTransport connection")?;
+                            let wrpc = wrpc_transport_web::Client::from(conn);
+                            loop {
+                                srv.accept(&wrpc)
+                                    .await
+                                    .context("failed to accept wRPC connection")?;
+                            }
+                        });
+                    }
+                    Some(res) = tasks.join_next() => {
+                        match res {
+                            Ok(Ok(())) => {}
+                            Ok(Err(err)) => warn!(?err, "failed to serve connection"),
+                            Err(err) => error!(?err, "failed to join task"),
+                        }
+                    }
+                    else => return,
+                }
+            }
+        }
+    });
+
+    // NOTE: This will conflate all invocation streams into a single stream via `futures::stream::SelectAll`,
+    // to customize this, iterate over the returned `invocations` and set up custom handling per export
+    let mut invocations = select_all(
+        invocations
+            .into_iter()
+            .map(|(instance, name, invocations)| invocations.map(move |res| (instance, name, res))),
+    );
+    let shutdown = signal::ctrl_c();
+    let mut shutdown = pin!(shutdown);
+    let mut tasks = JoinSet::new();
+    loop {
+        select! {
+            Some((instance, name, res)) = invocations.next() => {
+                match res {
+                    Ok(fut) => {
+                        debug!(instance, name, "invocation accepted");
+                        tasks.spawn(async move {
+                            if let Err(err) = fut.await {
+                                warn!(?err, "failed to handle invocation");
+                            } else {
+                                info!(instance, name, "invocation successfully handled");
+                            }
+                        });
+                    }
+                    Err(err) => {
+                        warn!(?err, instance, name, "failed to accept invocation");
+                    }
+                }
+            }
+            Some(res) = tasks.join_next() => {
+                if let Err(err) = res {
+                    error!(?err, "failed to join task")
+                }
+            }
+            res = &mut shutdown => {
+                accept.abort();
+                while let Some(res) = tasks.join_next().await {
+                    if let Err(err) = res {
+                        error!(?err, "failed to join task")
+                    }
+                }
+                return res.context("failed to listen for ^C")
+            }
+        }
+    }
+}

--- a/examples/rust/streams-web-server/wit/deps.lock
+++ b/examples/rust/streams-web-server/wit/deps.lock
@@ -1,0 +1,4 @@
+[streams]
+path = "../../../wit/streams"
+sha256 = "5064bee90ebea73f1695987191fbbfea71ed2dbb69839814009490b4fbe8e96f"
+sha512 = "dfca3844d91c6c8e83fefd7b9511a366b464cf69d017c61b671409cb26dc9490a0e59a8e60ef15b77fdeb4fc1b8d9e6efa11c2fb1a1dabd0141e5e6afe8a59b9"

--- a/examples/rust/streams-web-server/wit/deps.toml
+++ b/examples/rust/streams-web-server/wit/deps.toml
@@ -1,0 +1,1 @@
+streams = "../../../wit/streams"

--- a/examples/rust/streams-web-server/wit/deps/streams/streams.wit
+++ b/examples/rust/streams-web-server/wit/deps/streams/streams.wit
@@ -1,0 +1,17 @@
+package wrpc-examples:streams;
+
+interface handler {
+    record req {
+        numbers: stream<u64>,
+        bytes: stream<u8>,
+    }
+    echo: func(r: req) -> (numbers: stream<u64>, bytes: stream<u8>);
+}
+
+world client {
+    import handler;
+}
+
+world server {
+    export handler;
+}

--- a/examples/rust/streams-web-server/wit/world.wit
+++ b/examples/rust/streams-web-server/wit/world.wit
@@ -1,0 +1,5 @@
+package wrpc-examples:streams-rust-server;
+
+world server {
+    include wrpc-examples:streams/server;
+}


### PR DESCRIPTION
Closes #479.

Adds `streams-web-client` and `streams-web-server` examples, matching the existing `streams-nats-{client,server}`, `streams-quic-{client,server}`, and `streams-tcp-{client,server}` pairs.

The WebTransport transport uses `wtransport` with a self-signed certificate (generated via `rcgen` at startup) and an `Insecure` cert verifier on the client side — the same pattern as the existing `hello-web-{client,server}` and `wasi-keyvalue-web-server` examples.

Both examples implement `wrpc-examples:streams/handler.echo`, echoing back a stream of numbers and a stream of bytes.

**Running:**
```
# terminal 1
cargo run -p streams-web-server

# terminal 2
cargo run -p streams-web-client "https://[::1]:4433"
```

Note: on macOS `localhost` may resolve to `127.0.0.1` rather than `::1`, so pass the explicit IPv6 address when the server is bound to `[::1]` (the default).