### PR TITLE
fix(nats): apply subscription commands before routing messages

### DIFF
--- a/crates/transport-nats/src/lib.rs
+++ b/crates/transport-nats/src/lib.rs
@@ -248,8 +248,18 @@ impl Client {
                 let mut subs = HashMap::new();
                 loop {
                     select! {
-                        Some(msg) = sub.next() => handle_message(&mut subs, msg).await,
+                        // NOTE: `biased` ensures that pending subscription commands are always
+                        // applied before incoming messages are routed. Every wRPC subscription is
+                        // registered via `Command::Subscribe` before the matching data is
+                        // published, but both reach this single demux task as independent ready
+                        // events. Without biasing, `select!` picks a ready branch at random and may
+                        // route a message before its `Subscribe` command is applied, dropping it as
+                        // having "no subscriber" and hanging the consumer forever. This races more
+                        // easily under load, when the task is scheduled less frequently and a
+                        // queued command and an arrived message are both ready in the same poll.
+                        biased;
                         Some(cmd) = cmd_rx.recv() => handle_command(&mut subs, cmd),
+                        Some(msg) = sub.next() => handle_message(&mut subs, msg).await,
                         else => return,
                     }
                 }


### PR DESCRIPTION
## Problem

`rust_bindgen_nats_async` hangs indefinitely in CI (observed running for 28+ minutes under `cargo nextest run --cargo-profile release -j4`).

## Root cause

The NATS transport multiplexes every subject through a single `inbox.>` subscription feeding one demux task. That task's `select!` loop was **unbiased** and listed message routing before command handling:

```rust
select! {
    Some(msg) = sub.next() => handle_message(&mut subs, msg).await,
    Some(cmd) = cmd_rx.recv() => handle_command(&mut subs, cmd),
    else => return,
}
```

Every wRPC subscription is registered (`Command::Subscribe`) *before* the matching data is published, but the command and the data reach the demux task as two independent ready events. `tokio::select!` picks a ready branch **at random**, so when both are ready in the same poll it can route the message *before* its `Subscribe` is applied — finding "no subscriber", dropping the message, and hanging the stream consumer forever.

It only surfaces under load (release + `-j4` in CI), where the demux task is scheduled less often and the two events pile up together; on idle/fast hardware the command is always drained before the data arrives, so it never reproduces locally.

## Fix

Add `biased;` and handle commands before messages, so pending subscription state is always applied before any message is routed. Applying a `Subscribe`/`Unsubscribe` ahead of a message is always safe, and the protocol always registers a subscription before publishing its data.

## Verification

- Reproduced by inserting a 5 ms delay before the `select!` to force branch simultaneity: **4/8 runs hung**, debug logs showing dropped `.results` / `.results.0` (async stream sub-channel) messages.
- With the fix + same stress delay: **12/12 pass**.
- Full NATS rust suite passes: `rust_bindgen_nats_async`, `rust_bindgen_nats_sync`, `rust_dynamic_nats`.
- `cargo fmt` and `cargo clippy -p wrpc-transport-nats --all-targets` clean.

The Go NATS transport uses per-subject native `conn.Subscribe(subject, callback)` registrations (no single multiplexed demux loop), so it does not share this race and needs no mirrored change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)