### PR TITLE
ci: use v2 registries.conf for skopeo in oci job

### DIFF
--- a/.github/workflows/wrpc.yml
+++ b/.github/workflows/wrpc.yml
@@ -333,6 +333,10 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       packages: write
+    env:
+      # The runner ships a v1-format /etc/containers/registries.conf, which the
+      # newer skopeo from nixpkgs-unstable rejects. Point it at our own v2 file.
+      CONTAINERS_REGISTRIES_CONF: ${{ github.workspace }}/.github/registries.conf
     needs:
       - build-bin
       - test-linux
@@ -363,6 +367,9 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Write v2 `registries.conf`
+        run: printf 'unqualified-search-registries = ["docker.io"]\n' > "${CONTAINERS_REGISTRIES_CONF}"
 
       - name: Install `skopeo`
         run: nix profile install --inputs-from . 'nixpkgs-unstable#skopeo'


### PR DESCRIPTION
## Problem

The `oci` job installs `skopeo` from `nixpkgs-unstable`, which is newer than the version bundled on the `ubuntu-24.04` runner. The newer skopeo rejects the runner's pre-existing **v1**-format `/etc/containers/registries.conf`, failing the push step:

```
initializing destination docker://ghcr.io/bytecodealliance/wrpc:<sha>: getting username and password: loading registries configuration "/etc/containers/registries.conf": registries.conf must be in v2 format but is in v1
```

## Fix

- Set `CONTAINERS_REGISTRIES_CONF` (job-level `env`) so every `skopeo` invocation uses our own config instead of the runner's `/etc/containers/registries.conf`.
- Add a step that writes a minimal valid **v2** config before skopeo is installed/used.

The references used in this job are fully-qualified (`ghcr.io/...`, `docker-daemon:`, `oci-archive:`), so the minimal config is sufficient and no system files are touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)