### PR TITLE
refactor(transport): take `&mut self` in `Accept::accept`

### DIFF
--- a/crates/transport-quic/src/lib.rs
+++ b/crates/transport-quic/src/lib.rs
@@ -113,7 +113,7 @@ impl Accept for &Client {
     type Outgoing = SendStream;
     type Incoming = RecvStream;
 
-    async fn accept(&self) -> std::io::Result<(Self::Context, Self::Outgoing, Self::Incoming)> {
+    async fn accept(&mut self) -> std::io::Result<(Self::Context, Self::Outgoing, Self::Incoming)> {
         let (tx, rx) = self.0.accept_bi().await?;
         Ok(((), tx, rx))
     }
@@ -124,7 +124,7 @@ impl Accept for Client {
     type Outgoing = SendStream;
     type Incoming = RecvStream;
 
-    async fn accept(&self) -> std::io::Result<(Self::Context, Self::Outgoing, Self::Incoming)> {
-        (&self).accept().await
+    async fn accept(&mut self) -> std::io::Result<(Self::Context, Self::Outgoing, Self::Incoming)> {
+        <&Self>::accept(&mut &*self).await
     }
 }

--- a/crates/transport-web/src/lib.rs
+++ b/crates/transport-web/src/lib.rs
@@ -129,7 +129,7 @@ impl Accept for &Client {
     type Outgoing = SendStream;
     type Incoming = RecvStream;
 
-    async fn accept(&self) -> std::io::Result<(Self::Context, Self::Outgoing, Self::Incoming)> {
+    async fn accept(&mut self) -> std::io::Result<(Self::Context, Self::Outgoing, Self::Incoming)> {
         let (tx, rx) = self.0.accept_bi().await.map_err(std::io::Error::other)?;
         Ok(((), tx, rx))
     }
@@ -140,7 +140,7 @@ impl Accept for Client {
     type Outgoing = SendStream;
     type Incoming = RecvStream;
 
-    async fn accept(&self) -> std::io::Result<(Self::Context, Self::Outgoing, Self::Incoming)> {
-        (&self).accept().await
+    async fn accept(&mut self) -> std::io::Result<(Self::Context, Self::Outgoing, Self::Incoming)> {
+        <&Self>::accept(&mut &*self).await
     }
 }

--- a/crates/transport/src/frame/conn/accept.rs
+++ b/crates/transport/src/frame/conn/accept.rs
@@ -18,8 +18,21 @@ pub trait Accept {
 
     /// Accept a connection returning a pair of streams and connection context
     fn accept(
-        &self,
+        &mut self,
     ) -> impl Future<Output = std::io::Result<(Self::Context, Self::Outgoing, Self::Incoming)>>;
+}
+
+impl<T> Accept for &mut T
+where
+    T: Accept,
+{
+    type Context = T::Context;
+    type Outgoing = T::Outgoing;
+    type Incoming = T::Incoming;
+
+    async fn accept(&mut self) -> std::io::Result<(Self::Context, Self::Outgoing, Self::Incoming)> {
+        (**self).accept().await
+    }
 }
 
 /// Wrapper returned by [`AcceptExt::map_context`]
@@ -62,33 +75,34 @@ where
     type Outgoing = T::Outgoing;
     type Incoming = T::Incoming;
 
-    async fn accept(&self) -> std::io::Result<(Self::Context, Self::Outgoing, Self::Incoming)> {
-        (&self).accept().await
-    }
-}
-
-impl<T, U, F> Accept for &AcceptMapContext<T, F>
-where
-    T: Accept,
-    U: Send + Sync + 'static,
-    F: Fn(T::Context) -> U,
-{
-    type Context = U;
-    type Outgoing = T::Outgoing;
-    type Incoming = T::Incoming;
-
-    async fn accept(&self) -> std::io::Result<(Self::Context, Self::Outgoing, Self::Incoming)> {
+    async fn accept(&mut self) -> std::io::Result<(Self::Context, Self::Outgoing, Self::Incoming)> {
         let (cx, tx, rx) = self.inner.accept().await?;
         Ok(((self.f)(cx), tx, rx))
     }
 }
 
+impl<'a, T, U, F> Accept for &'a AcceptMapContext<T, F>
+where
+    &'a T: Accept,
+    U: Send + Sync + 'static,
+    F: Fn(<&'a T as Accept>::Context) -> U,
+{
+    type Context = U;
+    type Outgoing = <&'a T as Accept>::Outgoing;
+    type Incoming = <&'a T as Accept>::Incoming;
+
+    async fn accept(&mut self) -> std::io::Result<(Self::Context, Self::Outgoing, Self::Incoming)> {
+        let (cx, tx, rx) = <&'a T>::accept(&mut &self.inner).await?;
+        Ok(((self.f)(cx), tx, rx))
+    }
+}
+
 /// A wrapper around a [Stream] of connections
-pub struct AcceptStream<T>(tokio::sync::Mutex<T>);
+pub struct AcceptStream<T>(T);
 
 impl<T> From<T> for AcceptStream<T> {
     fn from(stream: T) -> Self {
-        Self(tokio::sync::Mutex::new(stream))
+        Self(stream)
     }
 }
 
@@ -103,25 +117,8 @@ where
     type Outgoing = O;
     type Incoming = I;
 
-    async fn accept(&self) -> std::io::Result<(Self::Context, Self::Outgoing, Self::Incoming)> {
-        (&self).accept().await
-    }
-}
-
-impl<T, C, O, I> Accept for &AcceptStream<T>
-where
-    T: Stream<Item = (C, O, I)> + Unpin,
-    C: Send + Sync + 'static,
-    O: AsyncWrite + Send + Sync + Unpin + 'static,
-    I: AsyncRead + Send + Sync + Unpin + 'static,
-{
-    type Context = C;
-    type Outgoing = O;
-    type Incoming = I;
-
-    async fn accept(&self) -> std::io::Result<(Self::Context, Self::Outgoing, Self::Incoming)> {
-        let mut stream = self.0.lock().await;
-        let Some((cx, tx, rx)) = stream.next().await else {
+    async fn accept(&mut self) -> std::io::Result<(Self::Context, Self::Outgoing, Self::Incoming)> {
+        let Some((cx, tx, rx)) = self.0.next().await else {
             return Err(std::io::ErrorKind::UnexpectedEof.into());
         };
         Ok((cx, tx, rx))
@@ -129,11 +126,11 @@ where
 }
 
 /// A wrapper around an [mpsc::Receiver] of connections
-pub struct AcceptReceiver<C, O, I>(tokio::sync::Mutex<mpsc::Receiver<(C, O, I)>>);
+pub struct AcceptReceiver<C, O, I>(mpsc::Receiver<(C, O, I)>);
 
 impl<C, O, I> From<mpsc::Receiver<(C, O, I)>> for AcceptReceiver<C, O, I> {
     fn from(stream: mpsc::Receiver<(C, O, I)>) -> Self {
-        Self(tokio::sync::Mutex::new(stream))
+        Self(stream)
     }
 }
 
@@ -147,24 +144,8 @@ where
     type Outgoing = O;
     type Incoming = I;
 
-    async fn accept(&self) -> std::io::Result<(Self::Context, Self::Outgoing, Self::Incoming)> {
-        (&self).accept().await
-    }
-}
-
-impl<C, O, I> Accept for &AcceptReceiver<C, O, I>
-where
-    C: Send + Sync + 'static,
-    O: AsyncWrite + Send + Sync + Unpin + 'static,
-    I: AsyncRead + Send + Sync + Unpin + 'static,
-{
-    type Context = C;
-    type Outgoing = O;
-    type Incoming = I;
-
-    async fn accept(&self) -> std::io::Result<(Self::Context, Self::Outgoing, Self::Incoming)> {
-        let mut stream = self.0.lock().await;
-        let Some((cx, tx, rx)) = stream.recv().await else {
+    async fn accept(&mut self) -> std::io::Result<(Self::Context, Self::Outgoing, Self::Incoming)> {
+        let Some((cx, tx, rx)) = self.0.recv().await else {
             return Err(std::io::ErrorKind::UnexpectedEof.into());
         };
         Ok((cx, tx, rx))
@@ -172,11 +153,11 @@ where
 }
 
 /// A wrapper around an [mpsc::UnboundedReceiver] of connections
-pub struct AcceptUnboundedReceiver<C, O, I>(tokio::sync::Mutex<mpsc::UnboundedReceiver<(C, O, I)>>);
+pub struct AcceptUnboundedReceiver<C, O, I>(mpsc::UnboundedReceiver<(C, O, I)>);
 
 impl<C, O, I> From<mpsc::UnboundedReceiver<(C, O, I)>> for AcceptUnboundedReceiver<C, O, I> {
     fn from(stream: mpsc::UnboundedReceiver<(C, O, I)>) -> Self {
-        Self(tokio::sync::Mutex::new(stream))
+        Self(stream)
     }
 }
 
@@ -190,24 +171,8 @@ where
     type Outgoing = O;
     type Incoming = I;
 
-    async fn accept(&self) -> std::io::Result<(Self::Context, Self::Outgoing, Self::Incoming)> {
-        (&self).accept().await
-    }
-}
-
-impl<C, O, I> Accept for &AcceptUnboundedReceiver<C, O, I>
-where
-    C: Send + Sync + 'static,
-    O: AsyncWrite + Send + Sync + Unpin + 'static,
-    I: AsyncRead + Send + Sync + Unpin + 'static,
-{
-    type Context = C;
-    type Outgoing = O;
-    type Incoming = I;
-
-    async fn accept(&self) -> std::io::Result<(Self::Context, Self::Outgoing, Self::Incoming)> {
-        let mut stream = self.0.lock().await;
-        let Some((cx, tx, rx)) = stream.recv().await else {
+    async fn accept(&mut self) -> std::io::Result<(Self::Context, Self::Outgoing, Self::Incoming)> {
+        let Some((cx, tx, rx)) = self.0.recv().await else {
             return Err(std::io::ErrorKind::UnexpectedEof.into());
         };
         Ok((cx, tx, rx))

--- a/crates/transport/src/frame/conn/server.rs
+++ b/crates/transport/src/frame/conn/server.rs
@@ -96,7 +96,7 @@ where
     #[instrument(level = "trace", skip_all, ret(level = "trace"))]
     pub async fn accept(
         &self,
-        listener: impl Accept<Context = C, Incoming = I, Outgoing = O>,
+        mut listener: impl Accept<Context = C, Incoming = I, Outgoing = O>,
     ) -> Result<(), AcceptError<C, I, O>> {
         let (cx, tx, mut rx) = listener.accept().await.map_err(AcceptError::IO)?;
         let mut instance = String::default();

--- a/crates/transport/src/frame/oneshot.rs
+++ b/crates/transport/src/frame/oneshot.rs
@@ -114,22 +114,8 @@ where
     type Outgoing = O;
     type Incoming = I;
 
-    async fn accept(&self) -> std::io::Result<(Self::Context, Self::Outgoing, Self::Incoming)> {
-        (&self).accept().await
-    }
-}
-
-impl<I, O> Accept for &Oneshot<I, O>
-where
-    I: AsyncRead + Send + Sync + Unpin + 'static,
-    O: AsyncWrite + Send + Sync + Unpin + 'static,
-{
-    type Context = ();
-    type Outgoing = O;
-    type Incoming = I;
-
     #[instrument(level = "trace", skip(self))]
-    async fn accept(&self) -> std::io::Result<(Self::Context, Self::Outgoing, Self::Incoming)> {
+    async fn accept(&mut self) -> std::io::Result<(Self::Context, Self::Outgoing, Self::Incoming)> {
         let (rx, tx) = self.try_take_inner()?;
         Ok(((), tx, rx))
     }

--- a/crates/transport/src/frame/tcp/tokio.rs
+++ b/crates/transport/src/frame/tcp/tokio.rs
@@ -95,8 +95,8 @@ impl Accept for TcpListener {
     type Outgoing = OwnedWriteHalf;
     type Incoming = OwnedReadHalf;
 
-    async fn accept(&self) -> std::io::Result<(Self::Context, Self::Outgoing, Self::Incoming)> {
-        (&self).accept().await
+    async fn accept(&mut self) -> std::io::Result<(Self::Context, Self::Outgoing, Self::Incoming)> {
+        <&Self>::accept(&mut &*self).await
     }
 }
 
@@ -106,7 +106,7 @@ impl Accept for &TcpListener {
     type Incoming = OwnedReadHalf;
 
     #[instrument(level = "trace")]
-    async fn accept(&self) -> std::io::Result<(Self::Context, Self::Outgoing, Self::Incoming)> {
+    async fn accept(&mut self) -> std::io::Result<(Self::Context, Self::Outgoing, Self::Incoming)> {
         let (stream, addr) = TcpListener::accept(self).await?;
         let (rx, tx) = stream.into_split();
         Ok((addr, tx, rx))

--- a/crates/transport/src/frame/unix.rs
+++ b/crates/transport/src/frame/unix.rs
@@ -157,8 +157,8 @@ impl Accept for UnixListener {
     type Outgoing = OwnedWriteHalf;
     type Incoming = OwnedReadHalf;
 
-    async fn accept(&self) -> std::io::Result<(Self::Context, Self::Outgoing, Self::Incoming)> {
-        (&self).accept().await
+    async fn accept(&mut self) -> std::io::Result<(Self::Context, Self::Outgoing, Self::Incoming)> {
+        <&Self>::accept(&mut &*self).await
     }
 }
 
@@ -168,7 +168,7 @@ impl Accept for &UnixListener {
     type Incoming = OwnedReadHalf;
 
     #[instrument(level = "trace")]
-    async fn accept(&self) -> std::io::Result<(Self::Context, Self::Outgoing, Self::Incoming)> {
+    async fn accept(&mut self) -> std::io::Result<(Self::Context, Self::Outgoing, Self::Incoming)> {
         let (stream, addr) = UnixListener::accept(self).await?;
         let (rx, tx) = stream.into_split();
         Ok((addr, tx, rx))


### PR DESCRIPTION
Changes the `Accept::accept` receiver from `&self` to `&mut self`.

## What changed

- `Accept::accept(&self)` → `accept(&mut self)`.
- Shared-reference acceptors keep their `Accept` impls, so call sites are unchanged and still pass `&listener`:
  - `&TcpListener`, `&UnixListener`
  - `&wrpc_transport_quic::Client`, `&wrpc_transport_web::Client`
  - `&AcceptMapContext<T, F>` (now bounded on `&'a T: Accept`)
- Owned impls delegate to the reference impls via `<&Self>::accept(&mut &*self)`, and a blanket `impl<T: Accept> Accept for &mut T` forwards mutable references.
- `Server::accept` now takes `mut listener`.
- Since `accept` has exclusive access, the interior `Mutex`es on `AcceptStream`, `AcceptReceiver`, and `AcceptUnboundedReceiver` are removed. `Oneshot` keeps its `Mutex` because its `Invoke` impl still borrows `&self`.

## Testing

- `cargo build --workspace --all-features --tests`
- `cargo clippy -p wrpc-transport -p wrpc-transport-quic -p wrpc-transport-web --all-features --tests` (clean)
- `cargo fmt --all`
- TCP / Unix / oneshot / map_context tests (`cargo test --test rust`) and QUIC/web loopback tests pass.

> Draft description — please review/edit before merge.