### PR TITLE
ci: fix always-true nextest guard in cargo job

### DIFF
--- a/.github/workflows/wrpc.yml
+++ b/.github/workflows/wrpc.yml
@@ -197,9 +197,9 @@ jobs:
         with:
           cachixAuthToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - run: go work vendor -e -v
-        if: ${{ matrix.check }} == "nextest" 
+        if: ${{ matrix.check == 'nextest' }}
       - run: git add .
-        if: ${{ matrix.check }} == "nextest" 
+        if: ${{ matrix.check == 'nextest' }}
       - run: nix build -L .#checks.x86_64-linux.${{ matrix.check }}
 
   crates:


### PR DESCRIPTION
`if: ${{ matrix.check }} == "nextest"` interpolates to a non-empty string, which is always truthy, so `go work vendor` and `git add .` ran for every cargo check (audit/fmt/clippy) instead of only nextest. Wrap the comparison inside the expression so it evaluates as a boolean.