### PR TITLE
build: specify version for wrpc-pack dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -176,6 +176,7 @@ wit-component = { version = "0.252", default-features = false }
 wit-parser = { version = "0.220", default-features = false }
 wrpc-cli = { version = "0.8", path = "./crates/cli", default-features = false }
 wrpc-introspect = { version = "0.7", default-features = false, path = "./crates/introspect" }
+wrpc-pack = { version = "0.4", path = "./crates/pack", default-features = false }
 wrpc-runtime-wasmtime = { version = "0.31", path = "./crates/runtime-wasmtime", default-features = false }
 wrpc-test = { path = "./crates/test", default-features = false }
 wrpc-transport = { version = "0.29", path = "./crates/transport", default-features = false }

--- a/crates/wave/Cargo.toml
+++ b/crates/wave/Cargo.toml
@@ -24,7 +24,7 @@ tokio-util = { workspace = true, features = ["codec"] }
 tracing = { workspace = true, features = ["attributes"] }
 wasm-tokio = { workspace = true }
 wasm-wave = { workspace = true }
-wrpc-pack = { path = "../pack", optional = true }
+wrpc-pack = { workspace = true, optional = true }
 wrpc-transport = { workspace = true }
 
 [dev-dependencies]


### PR DESCRIPTION
cargo publish rejects the wrpc-wave manifest because its wrpc-pack dependency is a bare path dependency with no version requirement. Move wrpc-pack into [workspace.dependencies] with a version (matching the convention for all other inter-crate deps) and reference it via workspace = true from crates/wave.