### PR TITLE
feat: add browser MessagePort transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1025,7 +1025,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2102,6 +2102,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "minicov"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4869b6a491569605d66d3952bcdf03df789e5b536e5f0cf7758a7f08a55ae24d"
+dependencies = [
+ "cc",
+ "walkdir",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2186,6 +2196,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -2768,7 +2779,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2857,7 +2868,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3285,7 +3296,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4102,6 +4113,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-test"
+version = "0.3.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d16931d57bcdd6a0dcc11254bdd1388827690c1b6807f0d2836f59a4f9eb30ac"
+dependencies = [
+ "async-trait",
+ "cast",
+ "js-sys",
+ "libm",
+ "minicov",
+ "nu-ansi-term",
+ "num-traits",
+ "oorandom",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+ "wasm-bindgen-test-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fccaddcb2cd722baa7453b4c3d2cb2a3071597bb91f7a4373e8775bdb151778c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "wasm-bindgen-test-shared"
+version = "0.2.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3746ad029217960123cf2ebf939dda51eb931ba9f8f09c117e39c820b96aa794"
+
+[[package]]
 name = "wasm-encoder"
 version = "0.251.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4610,7 +4660,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5085,6 +5135,7 @@ dependencies = [
  "wit-bindgen-wrpc-rust",
  "wit-bindgen-wrpc-test",
  "wrpc-cli",
+ "wrpc-message-channel",
  "wrpc-quic",
  "wrpc-test",
  "wrpc-transport",
@@ -5106,6 +5157,24 @@ name = "wrpc-introspect"
 version = "0.7.0"
 dependencies = [
  "wit-parser 0.251.0",
+]
+
+[[package]]
+name = "wrpc-message-channel"
+version = "0.1.0"
+dependencies = [
+ "bytes",
+ "futures",
+ "js-sys",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test",
+ "web-sys",
+ "wrpc-transport",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ bin-wasmtime = ["dep:tokio", "dep:wrpc-wasmtime-cli", "tokio/rt-multi-thread"]
 net = ["wrpc-transport/net"]
 quic = ["dep:wrpc-quic"]
 wasmtime = ["dep:wrpc-wasmtime"]
+message-channel = ["dep:wrpc-message-channel"]
 webtransport = ["dep:wrpc-webtransport"]
 websockets = [
     "dep:wrpc-websockets",
@@ -83,6 +84,7 @@ wit-bindgen-wrpc-go = { workspace = true, optional = true }
 wit-bindgen-wrpc-rust = { workspace = true, optional = true }
 wit-bindgen-wrpc-test = { workspace = true, optional = true }
 wrpc-cli = { workspace = true, optional = true }
+wrpc-message-channel = { workspace = true, optional = true }
 wrpc-quic = { workspace = true, optional = true }
 wrpc-transport = { workspace = true }
 wrpc-wasmtime = { workspace = true, optional = true }
@@ -139,6 +141,7 @@ http = { version = "1", default-features = false }
 humantime = { version = "2.1", default-features = false }
 hyper = { version = "1", default-features = false }
 hyper-util = { version = "0.1", default-features = false }
+js-sys = { version = "0.3", default-features = false }
 nuid = { version = "0.6", default-features = false }
 pin-project-lite = { version = "0.2", default-features = false }
 prettyplease = { version = "0.2.37", default-features = false }
@@ -171,8 +174,12 @@ url = { version = "2" }
 uuid = { version = "1", default-features = false }
 wasi = { version = "0.14", default-features = false }
 wasi-preview1-component-adapter-provider = { version = "46", default-features = false }
+wasm-bindgen = { version = "0.2", default-features = false }
+wasm-bindgen-futures = { version = "0.4", default-features = false }
+wasm-bindgen-test = { version = "0.3", default-features = false }
 wasm-tokio = { version = "0.6.1", default-features = false }
 wasm-wave = { version = "0.252", default-features = false }
+web-sys = { version = "0.3", default-features = false }
 wasmparser = { version = "0.252", default-features = false }
 wasmtime = { version = "46", default-features = false }
 wasmtime-cli-flags = { version = "46", default-features = false }
@@ -189,6 +196,7 @@ wit-component = { version = "0.252", default-features = false }
 wit-parser = { version = "0.251", default-features = false }
 wrpc-cli = { version = "0.8", path = "./crates/cli", default-features = false }
 wrpc-introspect = { version = "0.7", default-features = false, path = "./crates/introspect" }
+wrpc-message-channel = { version = "0.1", path = "./crates/message-channel", default-features = false }
 wrpc-pack = { version = "0.4", path = "./crates/pack", default-features = false }
 wrpc-quic = { version = "0.1", path = "./crates/quic", default-features = false }
 wrpc-test = { path = "./crates/test", default-features = false }

--- a/crates/message-channel/Cargo.toml
+++ b/crates/message-channel/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "wrpc-message-channel"
+version = "0.1.0"
+description = "wRPC browser MessagePort transport"
+
+authors.workspace = true
+categories.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[target.'cfg(target_family = "wasm")'.dependencies]
+bytes = { workspace = true }
+futures = { workspace = true, features = ["std"] }
+js-sys = { workspace = true }
+tokio = { workspace = true, features = ["sync"] }
+tokio-stream = { workspace = true }
+tokio-util = { workspace = true, features = ["io"] }
+tracing = { workspace = true, features = ["attributes"] }
+wasm-bindgen = { workspace = true }
+wasm-bindgen-futures = { workspace = true }
+web-sys = { workspace = true, features = [
+    "MessageChannel",
+    "MessageEvent",
+    "MessagePort",
+] }
+wrpc-transport = { workspace = true }
+
+[target.'cfg(target_family = "wasm")'.dev-dependencies]
+tokio = { workspace = true, features = ["io-util", "macros"] }
+wasm-bindgen-test = { workspace = true }
+web-sys = { workspace = true, features = ["MessageChannel"] }

--- a/crates/message-channel/src/lib.rs
+++ b/crates/message-channel/src/lib.rs
@@ -1,0 +1,199 @@
+//! wRPC transport over a browser [`MessagePort`].
+//!
+//! A [`MessagePort`] (one half of a [`web_sys::MessageChannel`], or a port
+//! transferred from a [`Worker`](web_sys::Worker), [`Window`](web_sys::Window),
+//! etc.) is a single, already-established, bidirectional message stream. It
+//! therefore maps onto a single wRPC connection, which the framed transport in
+//! [`wrpc_transport::frame`] multiplexes into the sub-streams of one
+//! invocation.
+//!
+//! [`connect`] bridges the event-based [`MessagePort`] API onto the
+//! [`AsyncRead`]/[`AsyncWrite`] byte-stream halves the framed transport
+//! expects. Because [`MessagePort`] (like all `web_sys` handles) is not [`Send`]
+//! while [`Invoke`](wrpc_transport::Invoke)/[`Serve`](wrpc_transport::Serve)
+//! require it, the port is moved into a task spawned with
+//! [`wasm_bindgen_futures::spawn_local`] and is reached only through [`Send`]
+//! channels; the returned halves are [`Send`] and satisfy the transport bounds.
+//!
+//! Each direction is framed as discrete messages: a [`Uint8Array`] carries a
+//! chunk of bytes, and a `null` message is the end-of-stream sentinel.
+//!
+//! Like every wRPC transport, the framed layer drives its work on a Tokio
+//! runtime; in the browser the caller is responsible for running one (e.g. a
+//! current-thread runtime pumped on the event loop), just as native callers
+//! supply `#[tokio::main]`.
+//!
+//! [`MessagePort`]: web_sys::MessagePort
+#![cfg(target_family = "wasm")]
+
+use core::pin::Pin;
+use core::task::{Context, Poll};
+
+use bytes::Bytes;
+use futures::channel::oneshot;
+use futures::Sink;
+use js_sys::Uint8Array;
+use tokio::sync::mpsc;
+use tokio_stream::wrappers::UnboundedReceiverStream;
+use tokio_util::io::{SinkWriter, StreamReader};
+use wasm_bindgen::closure::Closure;
+use wasm_bindgen::{JsCast as _, JsValue};
+use wasm_bindgen_futures::spawn_local;
+use web_sys::{MessageEvent, MessagePort};
+
+#[doc(no_inline)]
+pub use web_sys::MessagePort as Port;
+
+/// A message queued for posting to the [`MessagePort`] by the relay task.
+enum Out {
+    Data(Bytes),
+    Eof,
+}
+
+/// Outgoing half of a [`connect`]ed [`MessagePort`]: an [`AsyncWrite`] that
+/// relays written buffers to the port.
+///
+/// [`AsyncWrite`]: tokio::io::AsyncWrite
+pub type Outgoing = SinkWriter<OutgoingSink>;
+
+/// Incoming half of a [`connect`]ed [`MessagePort`]: an [`AsyncRead`] fed by
+/// messages received on the port.
+///
+/// [`AsyncRead`]: tokio::io::AsyncRead
+pub type Incoming = StreamReader<UnboundedReceiverStream<std::io::Result<Bytes>>, Bytes>;
+
+/// [`Invoke`](wrpc_transport::Invoke) implementation over a single
+/// [`MessagePort`].
+///
+/// [`Invoke::invoke`](wrpc_transport::Invoke::invoke) can only be called at most
+/// once, repeated calls will return an error.
+pub type Client = wrpc_transport::frame::Oneshot<Incoming, Outgoing>;
+
+/// [`Serve`](wrpc_transport::Serve) implementation over [`MessagePort`]
+/// connections fed in via [`Server::accept`](wrpc_transport::frame::Server::accept).
+pub type Server = wrpc_transport::frame::Server<(), Incoming, Outgoing>;
+
+/// [`Sink`] forwarding written buffers to the [`MessagePort`] relay task.
+pub struct OutgoingSink {
+    tx: mpsc::UnboundedSender<Out>,
+    eof_sent: bool,
+}
+
+fn broken_pipe() -> std::io::Error {
+    std::io::Error::new(
+        std::io::ErrorKind::BrokenPipe,
+        "MessagePort relay was dropped",
+    )
+}
+
+impl Sink<&[u8]> for OutgoingSink {
+    type Error = std::io::Error;
+
+    fn poll_ready(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn start_send(self: Pin<&mut Self>, buf: &[u8]) -> Result<(), Self::Error> {
+        self.get_mut()
+            .tx
+            .send(Out::Data(Bytes::copy_from_slice(buf)))
+            .map_err(|_| broken_pipe())
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_close(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        let this = self.get_mut();
+        if !this.eof_sent {
+            this.tx.send(Out::Eof).map_err(|_| broken_pipe())?;
+            this.eof_sent = true;
+        }
+        Poll::Ready(Ok(()))
+    }
+}
+
+/// Bridges a [`MessagePort`] into wRPC byte-stream halves: an [`AsyncWrite`]
+/// outgoing half and an [`AsyncRead`] incoming half, suitable for use with
+/// [`wrpc_transport::frame`] (see [`Client`] and [`Server`]).
+///
+/// The port is moved into a [`spawn_local`] task that owns it for the lifetime
+/// of the connection; the task closes the port once both halves have signalled
+/// end-of-stream.
+///
+/// [`AsyncRead`]: tokio::io::AsyncRead
+/// [`AsyncWrite`]: tokio::io::AsyncWrite
+#[must_use]
+pub fn connect(port: MessagePort) -> (Outgoing, Incoming) {
+    let (in_tx, in_rx) = mpsc::unbounded_channel::<std::io::Result<Bytes>>();
+    let (out_tx, mut out_rx) = mpsc::unbounded_channel::<Out>();
+    let (in_done_tx, in_done_rx) = oneshot::channel::<()>();
+
+    let mut in_tx = Some(in_tx);
+    let mut in_done = Some(in_done_tx);
+    let onmessage = Closure::<dyn FnMut(MessageEvent)>::new(move |ev: MessageEvent| {
+        let data = ev.data();
+        if data.is_null() || data.is_undefined() {
+            // End-of-stream sentinel: dropping the sender signals EOF to the reader.
+            in_tx = None;
+            if let Some(done) = in_done.take() {
+                let _ = done.send(());
+            }
+            return;
+        }
+        let item = match data.dyn_into::<Uint8Array>() {
+            Ok(buf) => Ok(Bytes::from(buf.to_vec())),
+            Err(_) => Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "unexpected non-binary MessagePort message",
+            )),
+        };
+        let err = item.is_err();
+        if in_tx
+            .as_ref()
+            .is_none_or(|tx| tx.send(item).is_err() || err)
+        {
+            // Either the reader was dropped or we forwarded a terminal error;
+            // tear the incoming half down either way.
+            in_tx = None;
+            if let Some(done) = in_done.take() {
+                let _ = done.send(());
+            }
+        }
+    });
+    port.set_onmessage(Some(onmessage.as_ref().unchecked_ref()));
+    port.start();
+
+    spawn_local(async move {
+        // Keep the port and its message handler alive for the duration of the relay.
+        let _onmessage = onmessage;
+        while let Some(out) = out_rx.recv().await {
+            let msg = match out {
+                Out::Data(buf) => JsValue::from(Uint8Array::from(buf.as_ref())),
+                Out::Eof => JsValue::NULL,
+            };
+            if port.post_message(&msg).is_err() {
+                break;
+            }
+        }
+        // Outgoing finished; wait for the peer to finish sending before closing.
+        let _ = in_done_rx.await;
+        port.close();
+    });
+
+    (
+        SinkWriter::new(OutgoingSink {
+            tx: out_tx,
+            eof_sent: false,
+        }),
+        StreamReader::new(UnboundedReceiverStream::new(in_rx)),
+    )
+}
+
+/// Constructs a [`Client`] over a single [`MessagePort`].
+#[must_use]
+pub fn client(port: MessagePort) -> Client {
+    let (tx, rx) = connect(port);
+    Client::from((rx, tx))
+}

--- a/crates/message-channel/tests/loopback.rs
+++ b/crates/message-channel/tests/loopback.rs
@@ -1,0 +1,39 @@
+#![cfg(target_family = "wasm")]
+
+use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+use web_sys::MessageChannel;
+use wrpc_message_channel::connect;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+/// Exercises the [`connect`] byte-stream bridge over both ends of a
+/// [`MessageChannel`]: bytes written to one port's outgoing half are read back
+/// on the other port's incoming half, in both directions, terminated by the
+/// end-of-stream sentinel.
+#[wasm_bindgen_test]
+async fn loopback() {
+    let chan = MessageChannel::new().expect("failed to create `MessageChannel`");
+    let (mut a_tx, mut a_rx) = connect(chan.port1());
+    let (mut b_tx, mut b_rx) = connect(chan.port2());
+
+    a_tx.write_all(b"ping")
+        .await
+        .expect("failed to write `ping`");
+    a_tx.shutdown().await.expect("failed to shut down port 1");
+    let mut buf = Vec::new();
+    b_rx.read_to_end(&mut buf)
+        .await
+        .expect("failed to read `ping`");
+    assert_eq!(buf, b"ping");
+
+    b_tx.write_all(b"pong")
+        .await
+        .expect("failed to write `pong`");
+    b_tx.shutdown().await.expect("failed to shut down port 2");
+    let mut buf = Vec::new();
+    a_rx.read_to_end(&mut buf)
+        .await
+        .expect("failed to read `pong`");
+    assert_eq!(buf, b"pong");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,9 @@
 pub mod transport {
     pub use wrpc_transport::*;
 
+    #[cfg(feature = "message-channel")]
+    pub use wrpc_message_channel as message_channel;
+
     #[cfg(feature = "quic")]
     pub use wrpc_quic as quic;
 


### PR DESCRIPTION
Add the `wrpc-message-channel` crate, a wRPC transport over a browser `MessagePort` (one half of a `MessageChannel`, or a port transferred from a worker/window). A `MessagePort` is a single established bidirectional message stream, so it maps onto one wRPC connection that the framed transport multiplexes into an invocation's sub-streams.

`connect` bridges the event-based `MessagePort` API onto the `AsyncRead`/`AsyncWrite` byte-stream halves the framed transport expects. Since `MessagePort` is `!Send` while `Invoke`/`Serve` require `Send`, the port is moved into a `spawn_local` task and reached only through `Send` channels; the returned halves are `Send` and satisfy the bounds. Each direction is framed as discrete messages: a `Uint8Array` carries a chunk of bytes and a `null` message is the end-of-stream sentinel. `Client` is a one-shot `Invoke` and `Server` reuses the framed server.

The crate is gated to `cfg(target_family = "wasm")` (empty elsewhere) and wired into the `wrpc` facade behind a non-default `message-channel` feature, re-exported as `transport::message_channel`.

Assisted-by: claude:claude-opus-4-8