### PR TITLE
chore: migrate workspace to Rust edition 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ repository.workspace = true
 [workspace.package]
 authors = ["Roman Volosatovs <rvolosatovs@riseup.net>"]
 categories = ["wasm"]
-edition = "2021"
+edition = "2024"
 homepage = "https://github.com/bytecodealliance/wrpc"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wrpc"

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -5,7 +5,7 @@ use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
 
-use anyhow::{bail, Context as _};
+use anyhow::{Context as _, bail};
 use bytes::Bytes;
 use clap::Parser as _;
 use criterion::measurement::Measurement;

--- a/crates/introspect/src/lib.rs
+++ b/crates/introspect/src/lib.rs
@@ -53,11 +53,11 @@ pub fn is_ty(resolve: &Resolve, expected: Type, ty: &Type) -> bool {
         if ty == expected {
             return true;
         }
-        if let Type::Id(id) = ty {
-            if let TypeDefKind::Type(t) = resolve.types[id].kind {
-                ty = t;
-                continue;
-            }
+        if let Type::Id(id) = ty
+            && let TypeDefKind::Type(t) = resolve.types[id].kind
+        {
+            ty = t;
+            continue;
         }
         return false;
     }

--- a/crates/nats/src/lib.rs
+++ b/crates/nats/src/lib.rs
@@ -5,14 +5,14 @@
 use core::future::Future;
 use core::iter::zip;
 use core::ops::{Deref, DerefMut};
-use core::pin::{pin, Pin};
-use core::task::{ready, Context, Poll};
+use core::pin::{Pin, pin};
+use core::task::{Context, Poll, ready};
 use core::{mem, str};
 
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use anyhow::{anyhow, ensure, Context as _};
+use anyhow::{Context as _, anyhow, ensure};
 use async_nats::message::OutboundMessage;
 use async_nats::{HeaderMap, ServerInfo, StatusCode, Subject};
 use bytes::{Buf as _, Bytes};
@@ -379,7 +379,7 @@ impl IndexTrie {
             //    nested.as_mut().and_then(|nested| nested.take(path))
             //}
             Self::Empty | Self::Leaf(..) | Self::WildcardNode { .. } => None,
-            Self::IndexNode { ref mut nested, .. } => nested
+            Self::IndexNode { nested, .. } => nested
                 .get_mut(*i)
                 .and_then(|nested| nested.as_mut().and_then(|nested| nested.take(path))),
         }
@@ -418,10 +418,7 @@ impl IndexTrie {
                 }
                 true
             }
-            Self::WildcardNode {
-                ref mut subscriber,
-                ref mut nested,
-            } => match (&subscriber, path) {
+            Self::WildcardNode { subscriber, nested } => match (&subscriber, path) {
                 (None, []) => {
                     *subscriber = Some(sub);
                     true
@@ -436,10 +433,7 @@ impl IndexTrie {
                 }
                 _ => false,
             },
-            Self::IndexNode {
-                ref mut subscriber,
-                ref mut nested,
-            } => match (&subscriber, path) {
+            Self::IndexNode { subscriber, nested } => match (&subscriber, path) {
                 (None, []) => {
                     *subscriber = Some(sub);
                     true
@@ -595,7 +589,7 @@ impl AsyncWrite for SubjectWriter {
                 return Poll::Ready(Err(std::io::Error::new(
                     std::io::ErrorKind::BrokenPipe,
                     err,
-                )))
+                )));
             }
             Poll::Ready(Ok(())) => {}
         }
@@ -1239,8 +1233,8 @@ impl wrpc_transport::Serve for Client {
         paths: Arc<[Box<[Option<usize>]>]>,
     ) -> anyhow::Result<
         impl Stream<Item = anyhow::Result<(Self::Context, Self::Outgoing, Self::Incoming)>>
-            + 'static
-            + use<>,
+        + 'static
+        + use<>,
     > {
         let subject = invocation_subject(&self.prefix, instance, func);
         let sub = if let Some(group) = &self.queue_group {

--- a/crates/quic/src/lib.rs
+++ b/crates/quic/src/lib.rs
@@ -4,8 +4,8 @@ use anyhow::Context as _;
 use bytes::Bytes;
 use quinn::{Connection, RecvStream, SendStream, VarInt};
 use tracing::{debug, error, trace, warn};
-use wrpc_transport::frame::{Incoming, InvokeBuilder, Outgoing};
 use wrpc_transport::Invoke;
+use wrpc_transport::frame::{Incoming, InvokeBuilder, Outgoing};
 
 /// QUIC server with graceful stream shutdown handling
 pub type Server = wrpc_transport::Server<(), RecvStream, SendStream, ConnHandler>;

--- a/crates/test/src/lib.rs
+++ b/crates/test/src/lib.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use anyhow::Context;
 use futures::TryStreamExt as _;
-use rcgen::{generate_simple_self_signed, CertifiedKey};
+use rcgen::{CertifiedKey, generate_simple_self_signed};
 use rustls::pki_types::{CertificateDer, PrivatePkcs8KeyDer};
 use rustls::version::TLS13;
 use rustls::{ClientConfig, RootCertStore, ServerConfig};

--- a/crates/transport/src/frame/conn/mod.rs
+++ b/crates/transport/src/frame/conn/mod.rs
@@ -1,7 +1,7 @@
 use core::future::Future;
 use core::mem;
 use core::pin::Pin;
-use core::task::{ready, Context, Poll};
+use core::task::{Context, Poll, ready};
 
 use std::sync::Arc;
 
@@ -16,7 +16,7 @@ use tokio_stream::wrappers::ReceiverStream;
 use tokio_util::codec::Encoder;
 use tokio_util::io::StreamReader;
 use tokio_util::sync::PollSender;
-use tracing::{debug, error, instrument, trace, Instrument as _, Span};
+use tracing::{Instrument as _, Span, debug, error, instrument, trace};
 use wasm_tokio::{AsyncReadLeb128 as _, Leb128Encoder};
 
 use crate::Index;
@@ -148,7 +148,7 @@ impl IndexTrie {
         };
         match self {
             Self::Empty | Self::Leaf { .. } | Self::WildcardNode { .. } => None,
-            Self::IndexNode { ref mut nested, .. } => nested
+            Self::IndexNode { nested, .. } => nested
                 .get_mut(*i)
                 .and_then(|nested| nested.as_mut().and_then(|nested| nested.take_rx(path))),
             // TODO: Demux the subscription
@@ -170,7 +170,7 @@ impl IndexTrie {
         };
         match self {
             Self::Empty | Self::Leaf { .. } | Self::WildcardNode { .. } => None,
-            Self::IndexNode { ref mut nested, .. } => {
+            Self::IndexNode { nested, .. } => {
                 let nested = nested.get_mut(*i)?;
                 let nested = nested.as_mut()?;
                 nested.get_tx(path)
@@ -189,17 +189,13 @@ impl IndexTrie {
             Self::Leaf { tx, .. } => {
                 mem::take(tx);
             }
-            Self::IndexNode {
-                tx, ref mut nested, ..
-            } => {
+            Self::IndexNode { tx, nested, .. } => {
                 mem::take(tx);
                 for nested in nested.iter_mut().flatten() {
                     nested.close_tx();
                 }
             }
-            Self::WildcardNode {
-                tx, ref mut nested, ..
-            } => {
+            Self::WildcardNode { tx, nested, .. } => {
                 mem::take(tx);
                 if let Some(nested) = nested {
                     nested.close_tx();
@@ -244,11 +240,7 @@ impl IndexTrie {
                 }
                 true
             }
-            Self::IndexNode {
-                ref mut tx,
-                ref mut rx,
-                ref mut nested,
-            } => match (&tx, &rx, path) {
+            Self::IndexNode { tx, rx, nested } => match (&tx, &rx, path) {
                 (None, None, []) => {
                     *tx = Some(sender);
                     *rx = receiver;
@@ -269,11 +261,7 @@ impl IndexTrie {
                 }
                 _ => false,
             },
-            Self::WildcardNode {
-                ref mut tx,
-                ref mut rx,
-                ref mut nested,
-            } => match (&tx, &rx, path) {
+            Self::WildcardNode { tx, rx, nested } => match (&tx, &rx, path) {
                 (None, None, []) => {
                     *tx = Some(sender);
                     *rx = receiver;

--- a/crates/transport/src/frame/conn/server.rs
+++ b/crates/transport/src/frame/conn/server.rs
@@ -1,19 +1,19 @@
 use core::fmt::{Debug, Display};
 use core::marker::PhantomData;
 
-use std::collections::{hash_map, HashMap};
+use std::collections::{HashMap, hash_map};
 use std::sync::Arc;
 
 use anyhow::bail;
 use futures::{Stream, StreamExt as _};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite};
-use tokio::sync::{mpsc, Mutex};
+use tokio::sync::{Mutex, mpsc};
 use tokio_stream::wrappers::ReceiverStream;
 use tracing::{instrument, trace};
 use wasm_tokio::AsyncReadCore as _;
 
-use crate::frame::{Conn, ConnHandler, Incoming, Outgoing};
 use crate::Serve;
+use crate::frame::{Conn, ConnHandler, Incoming, Outgoing};
 
 /// wRPC server for framed transports
 pub struct Server<C, I, O, H = ()> {
@@ -123,7 +123,9 @@ async fn serve<C, I, O, H>(
     instance: &str,
     func: &str,
     paths: Arc<[Box<[Option<usize>]>]>,
-) -> anyhow::Result<impl Stream<Item = anyhow::Result<(C, Outgoing, Incoming)>> + 'static>
+) -> anyhow::Result<
+    impl Stream<Item = anyhow::Result<(C, Outgoing, Incoming)>> + 'static + use<C, I, O, H>,
+>
 where
     C: Send + Sync + 'static,
     I: AsyncRead + Send + Sync + Unpin + 'static,
@@ -169,8 +171,8 @@ where
         paths: Arc<[Box<[Option<usize>]>]>,
     ) -> anyhow::Result<
         impl Stream<Item = anyhow::Result<(Self::Context, Self::Outgoing, Self::Incoming)>>
-            + 'static
-            + use<C, I, O, H>,
+        + 'static
+        + use<C, I, O, H>,
     > {
         serve(self, instance, func, paths).await
     }
@@ -194,8 +196,8 @@ where
         paths: Arc<[Box<[Option<usize>]>]>,
     ) -> anyhow::Result<
         impl Stream<Item = anyhow::Result<(Self::Context, Self::Outgoing, Self::Incoming)>>
-            + 'static
-            + use<'a, C, I, O, H>,
+        + 'static
+        + use<'a, C, I, O, H>,
     > {
         serve(self, instance, func, paths).await
     }

--- a/crates/transport/src/frame/oneshot.rs
+++ b/crates/transport/src/frame/oneshot.rs
@@ -3,11 +3,11 @@
 use core::future::Future;
 
 use bytes::Bytes;
-use tokio::io::{duplex, split, AsyncRead, AsyncWrite, DuplexStream, ReadHalf, WriteHalf};
+use tokio::io::{AsyncRead, AsyncWrite, DuplexStream, ReadHalf, WriteHalf, duplex, split};
 use tracing::instrument;
 
-use crate::frame::{invoke, Incoming, Outgoing};
 use crate::Invoke;
+use crate::frame::{Incoming, Outgoing, invoke};
 
 /// [Invoke] implementation in terms of a single stream pair.
 ///

--- a/crates/transport/src/frame/tcp/tokio.rs
+++ b/crates/transport/src/frame/tcp/tokio.rs
@@ -1,12 +1,12 @@
 //! wRPC TCP transport using [tokio]
 
-use anyhow::{bail, Context as _};
+use anyhow::{Context as _, bail};
 use bytes::Bytes;
 use tokio::net::{TcpStream, ToSocketAddrs};
 use tracing::instrument;
 
-use crate::frame::{invoke, Incoming, Outgoing};
 use crate::Invoke;
+use crate::frame::{Incoming, Outgoing, invoke};
 
 /// [Invoke] implementation in terms of a single [`TcpStream`]
 ///

--- a/crates/transport/src/frame/tcp/wasi.rs
+++ b/crates/transport/src/frame/tcp/wasi.rs
@@ -1,11 +1,11 @@
 //! wRPC TCP transport using `wasi:sockets`
 
 use core::pin::Pin;
-use core::task::{ready, Context, Poll, Waker};
+use core::task::{Context, Poll, Waker, ready};
 
 use std::sync::Arc;
 
-use anyhow::{bail, Context as _};
+use anyhow::{Context as _, bail};
 use bytes::Bytes;
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 use tokio::sync::mpsc;
@@ -18,10 +18,10 @@ use wasi::sockets::network::{
     IpAddress, IpAddressFamily, IpSocketAddress, Ipv4SocketAddress, Ipv6SocketAddress, Network,
 };
 use wasi::sockets::tcp::ShutdownType;
-use wasi::sockets::tcp_create_socket::{create_tcp_socket, TcpSocket};
+use wasi::sockets::tcp_create_socket::{TcpSocket, create_tcp_socket};
 
-use crate::frame::{Incoming, Outgoing};
 use crate::Invoke;
+use crate::frame::{Incoming, Outgoing};
 
 /// [Invoke] implementation of a TCP transport using `wasi:sockets`
 #[derive(Clone, Copy, Debug)]
@@ -94,7 +94,7 @@ impl AsyncRead for IncomingStream {
             Ok(chunk) => chunk,
             Err(StreamError::Closed) => return Poll::Ready(Ok(())),
             Err(StreamError::LastOperationFailed(err)) => {
-                return Poll::Ready(Err(std::io::Error::new(std::io::ErrorKind::Other, err)))
+                return Poll::Ready(Err(std::io::Error::new(std::io::ErrorKind::Other, err)));
             }
         };
         if chunk.is_empty() {

--- a/crates/transport/src/frame/unix.rs
+++ b/crates/transport/src/frame/unix.rs
@@ -3,12 +3,12 @@
 use std::path::{Path, PathBuf};
 
 use bytes::Bytes;
-use tokio::net::unix::{OwnedReadHalf, OwnedWriteHalf};
 use tokio::net::UnixStream;
+use tokio::net::unix::{OwnedReadHalf, OwnedWriteHalf};
 use tracing::instrument;
 
-use crate::frame::{invoke, Incoming, Outgoing};
 use crate::Invoke;
+use crate::frame::{Incoming, Outgoing, invoke};
 
 /// [Invoke] implementation in terms of a single [`UnixStream`].
 ///

--- a/crates/transport/src/invoke.rs
+++ b/crates/transport/src/invoke.rs
@@ -11,7 +11,7 @@ use futures::TryStreamExt as _;
 use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt as _};
 use tokio::{select, try_join};
 use tokio_util::codec::{Encoder as _, FramedRead};
-use tracing::{debug, instrument, trace, Instrument as _};
+use tracing::{Instrument as _, debug, instrument, trace};
 
 use crate::{Deferred as _, Incoming, Index, TupleDecode, TupleEncode};
 
@@ -123,9 +123,9 @@ pub trait InvokeExt: Invoke {
             Results,
             Option<
                 impl Future<Output = anyhow::Result<()>>
-                    + Send
-                    + 'static
-                    + use<Self, P, Params, Results, Paths>,
+                + Send
+                + 'static
+                + use<Self, P, Params, Results, Paths>,
             >,
         )>,
     > + Send
@@ -175,20 +175,21 @@ pub trait InvokeExt: Invoke {
                     .context("failed to receive sync results")?
                     .context("incomplete results")
             };
-            let results = if let Some(mut fut) = tx.take() {
-                let mut results = pin!(results);
-                select! {
-                    res = &mut results => {
-                        tx = Some(fut);
-                        res?
-                    }
-                    res = &mut fut => {
-                        res??;
-                        results.await?
+            let results = match tx.take() {
+                Some(mut fut) => {
+                    let mut results = pin!(results);
+                    select! {
+                        res = &mut results => {
+                            tx = Some(fut);
+                            res?
+                        }
+                        res = &mut fut => {
+                            res??;
+                            results.await?
+                        }
                     }
                 }
-            } else {
-                results.await?
+                _ => results.await?,
             };
             trace!("received sync results");
             let buffer = mem::take(dec.read_buffer_mut());

--- a/crates/transport/src/lib.rs
+++ b/crates/transport/src/lib.rs
@@ -31,7 +31,7 @@ pub use frame::tcp;
 pub use frame::unix;
 
 use core::mem;
-use core::pin::{pin, Pin};
+use core::pin::{Pin, pin};
 use core::task::{Context, Poll};
 
 use bytes::BytesMut;

--- a/crates/transport/src/serve.rs
+++ b/crates/transport/src/serve.rs
@@ -6,11 +6,11 @@ use core::pin::Pin;
 
 use std::sync::Arc;
 
-use anyhow::{bail, Context as _};
+use anyhow::{Context as _, bail};
 use futures::{SinkExt as _, Stream, TryStreamExt as _};
 use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt as _};
 use tokio_util::codec::{FramedRead, FramedWrite};
-use tracing::{debug, instrument, trace, Instrument as _, Span};
+use tracing::{Instrument as _, Span, debug, instrument, trace};
 
 use crate::{Deferred as _, Incoming, Index, TupleDecode, TupleEncode};
 
@@ -34,9 +34,9 @@ pub trait Serve: Sync {
     ) -> impl Future<
         Output = anyhow::Result<
             impl Stream<Item = anyhow::Result<(Self::Context, Self::Outgoing, Self::Incoming)>>
-                + Send
-                + 'static
-                + use<Self>,
+            + Send
+            + 'static
+            + use<Self>,
         >,
     > + Send;
 }
@@ -53,29 +53,28 @@ pub trait ServeExt: Serve {
     ) -> impl Future<
         Output = anyhow::Result<
             impl Stream<
-                    Item = anyhow::Result<(
-                        Self::Context,
-                        Params,
-                        Option<
-                            impl Future<Output = std::io::Result<()>>
-                                + Send
-                                + Unpin
-                                + 'static
-                                + use<Self, Params, Results>,
-                        >,
-                        impl FnOnce(
-                                Results,
-                            ) -> Pin<
-                                Box<dyn Future<Output = anyhow::Result<()>> + Send + 'static>,
-                            >
-                            + Send
-                            + 'static
-                            + use<Self, Params, Results>,
-                    )>,
-                >
-                + Send
-                + 'static
-                + use<Self, Params, Results>,
+                Item = anyhow::Result<(
+                    Self::Context,
+                    Params,
+                    Option<
+                        impl Future<Output = std::io::Result<()>>
+                        + Send
+                        + Unpin
+                        + 'static
+                        + use<Self, Params, Results>,
+                    >,
+                    impl FnOnce(
+                        Results,
+                    )
+                        -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'static>>
+                    + Send
+                    + 'static
+                    + use<Self, Params, Results>,
+                )>,
+            >
+            + Send
+            + 'static
+            + use<Self, Params, Results>,
         >,
     > + Send
     where
@@ -156,7 +155,7 @@ impl<T: Serve> ServeExt for T {}
 #[cfg(test)]
 mod tests {
     use bytes::Bytes;
-    use futures::{stream, StreamExt as _, TryStreamExt as _};
+    use futures::{StreamExt as _, TryStreamExt as _, stream};
 
     use crate::Captures;
 

--- a/crates/transport/src/value.rs
+++ b/crates/transport/src/value.rs
@@ -1,6 +1,6 @@
 use core::any::TypeId;
 use core::fmt::{self, Debug};
-use core::future::{pending, Future};
+use core::future::{Future, pending};
 use core::hash::{Hash, Hasher};
 use core::iter::zip;
 use core::marker::PhantomData;
@@ -18,16 +18,16 @@ use tokio::task::JoinSet;
 use tokio_stream::wrappers::ReceiverStream;
 use tokio_util::codec::{Encoder as _, FramedRead};
 use tokio_util::io::StreamReader;
-use tracing::{debug, error, instrument, trace, Instrument as _, Span};
+use tracing::{Instrument as _, Span, debug, error, instrument, trace};
 use wasm_tokio::cm::{
     BoolCodec, F32Codec, F64Codec, OptionDecoder, OptionEncoder, PrimValEncoder, ResultDecoder,
-    ResultEncoder, S16Codec, S32Codec, S64Codec, S8Codec, TupleDecoder, TupleEncoder, U16Codec,
-    U32Codec, U64Codec, U8Codec,
+    ResultEncoder, S8Codec, S16Codec, S32Codec, S64Codec, TupleDecoder, TupleEncoder, U8Codec,
+    U16Codec, U32Codec, U64Codec,
 };
 use wasm_tokio::{
     CoreNameDecoder, CoreNameEncoder, CoreVecDecoder, CoreVecDecoderBytes, CoreVecEncoderBytes,
-    Leb128DecoderI128, Leb128DecoderI16, Leb128DecoderI32, Leb128DecoderI64, Leb128DecoderI8,
-    Leb128DecoderU128, Leb128DecoderU16, Leb128DecoderU32, Leb128DecoderU64, Leb128DecoderU8,
+    Leb128DecoderI8, Leb128DecoderI16, Leb128DecoderI32, Leb128DecoderI64, Leb128DecoderI128,
+    Leb128DecoderU8, Leb128DecoderU16, Leb128DecoderU32, Leb128DecoderU64, Leb128DecoderU128,
     Leb128Encoder, Utf8Codec,
 };
 
@@ -944,7 +944,7 @@ const CANONICAL_NAN_F64: u64 = 0x7ff8_0000_0000_0000;
 /// match the Component Model canonical ABI, delegating the actual byte encoding
 /// and decoding to the wrapped `wasm-tokio` codec.
 macro_rules! impl_canonical_nan_codec {
-    ($name:ident, $inner:ty, $t:ty, $canon:expr) => {
+    ($name:ident, $inner:ty, $t:ty, $canon:expr_2021) => {
         #[doc = concat!("Canonicalizes `NaN`s on encode, wrapping [`", stringify!($inner), "`].")]
         #[derive(Debug, Default)]
         pub struct $name($inner);
@@ -1610,10 +1610,9 @@ where
                     let mut buf = BytesMut::default();
                     enc.encode(item, &mut buf)?;
                     w.write_all(&buf).await?;
-                    if let Some(f) = enc.take_deferred() {
-                        f(w, Vec::default()).await
-                    } else {
-                        Ok(())
+                    match enc.take_deferred() {
+                        Some(f) => f(w, Vec::default()).await,
+                        _ => Ok(()),
                     }
                 }
                 .instrument(span),

--- a/crates/wasi-keyvalue-redis/src/lib.rs
+++ b/crates/wasi-keyvalue-redis/src/lib.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use anyhow::Context as _;
 use bytes::Bytes;
-use redis::{aio::ConnectionManager, AsyncCommands as _};
+use redis::{AsyncCommands as _, aio::ConnectionManager};
 use tokio::sync::RwLock;
 use tracing::{instrument, trace};
 use uuid::Uuid;

--- a/crates/wasmtime-cli/src/lib.rs
+++ b/crates/wasmtime-cli/src/lib.rs
@@ -8,27 +8,27 @@ use core::time::Duration;
 use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 
-use anyhow::{anyhow, bail, Context as _};
+use anyhow::{Context as _, anyhow, bail};
 use clap::Parser;
 use futures::StreamExt as _;
 use tokio::fs;
 use tokio::sync::Mutex;
 use tokio::task::JoinSet;
-use tracing::{error, info, instrument, warn, Instrument as _, Span};
+use tracing::{Instrument as _, Span, error, info, instrument, warn};
 use url::Url;
 use wasi_preview1_component_adapter_provider::{
     WASI_SNAPSHOT_PREVIEW1_ADAPTER_NAME, WASI_SNAPSHOT_PREVIEW1_COMMAND_ADAPTER,
     WASI_SNAPSHOT_PREVIEW1_REACTOR_ADAPTER,
 };
-use wasmtime::component::{types, Component, InstancePre, Linker, ResourceTable, ResourceType};
+use wasmtime::component::{Component, InstancePre, Linker, ResourceTable, ResourceType, types};
 use wasmtime::{Engine, Store};
 use wasmtime_wasi::{WasiCtx, WasiCtxBuilder, WasiCtxView, WasiView};
-use wasmtime_wasi_http::p2::{WasiHttpCtxView, WasiHttpView};
 use wasmtime_wasi_http::WasiHttpCtx;
+use wasmtime_wasi_http::p2::{WasiHttpCtxView, WasiHttpView};
 use wrpc_transport::{Invoke, Serve};
 use wrpc_wasmtime::{
-    collect_component_resource_exports, collect_component_resource_imports, link_item, rpc,
     RemoteResource, ServeExt as _, SharedResourceTable, WrpcCtxView, WrpcView,
+    collect_component_resource_exports, collect_component_resource_imports, link_item, rpc,
 };
 
 mod nats;
@@ -139,17 +139,15 @@ fn use_pooling_allocator_by_default() -> anyhow::Result<Option<bool>> {
 }
 
 fn is_0_2(version: &str, min_patch: u64) -> bool {
-    if let Ok(semver::Version {
-        major,
-        minor,
-        patch,
-        pre,
-        build,
-    }) = version.parse()
-    {
-        major == 0 && minor == 2 && patch >= min_patch && pre.is_empty() && build.is_empty()
-    } else {
-        false
+    match version.parse() {
+        Ok(semver::Version {
+            major,
+            minor,
+            patch,
+            pre,
+            build,
+        }) => major == 0 && minor == 2 && patch >= min_patch && pre.is_empty() && build.is_empty(),
+        _ => false,
     }
 }
 
@@ -474,10 +472,13 @@ where
                             match invocation {
                                 Ok((_, fut)) => {
                                     info!("serving root function invocation");
-                                    if let Err(err) = fut.await {
-                                        warn!(?err, "failed to serve root function invocation");
-                                    } else {
-                                        info!("successfully served root function invocation");
+                                    match fut.await {
+                                        Err(err) => {
+                                            warn!(?err, "failed to serve root function invocation");
+                                        }
+                                        _ => {
+                                            info!("successfully served root function invocation");
+                                        }
                                     }
                                 }
                                 Err(err) => {
@@ -521,16 +522,16 @@ where
                                     match invocation {
                                         Ok((_, fut)) => {
                                             info!("serving instance function invocation");
-                                            if let Err(err) = fut.await {
+                                            match fut.await { Err(err) => {
                                                 warn!(
                                                     ?err,
                                                     "failed to serve instance function invocation"
                                                 );
-                                            } else {
+                                            } _ => {
                                                 info!(
                                                     "successfully served instance function invocation"
                                                 );
-                                            }
+                                            }}
                                         }
                                         Err(err) => {
                                             error!(
@@ -621,10 +622,13 @@ where
                             match invocation {
                                 Ok((_, fut)) => {
                                     info!("serving root function invocation");
-                                    if let Err(err) = fut.await {
-                                        warn!(?err, "failed to serve root function invocation");
-                                    } else {
-                                        info!("successfully served root function invocation");
+                                    match fut.await {
+                                        Err(err) => {
+                                            warn!(?err, "failed to serve root function invocation");
+                                        }
+                                        _ => {
+                                            info!("successfully served root function invocation");
+                                        }
                                     }
                                 }
                                 Err(err) => {
@@ -677,16 +681,16 @@ where
                                     match invocation {
                                         Ok((_, fut)) => {
                                             info!("serving instance function invocation");
-                                            if let Err(err) = fut.await {
+                                            match fut.await { Err(err) => {
                                                 warn!(
                                                     ?err,
                                                     "failed to serve instance function invocation"
                                                 );
-                                            } else {
+                                            } _ => {
                                                 info!(
                                                     "successfully served instance function invocation"
                                                 );
-                                            }
+                                            }}
                                         }
                                         Err(err) => {
                                             error!(

--- a/crates/wasmtime/src/codec.rs
+++ b/crates/wasmtime/src/codec.rs
@@ -1,13 +1,13 @@
 use core::future::Future;
 use core::iter::zip;
 use core::ops::{BitOrAssign, Shl};
-use core::pin::{pin, Pin};
+use core::pin::{Pin, pin};
 
 use std::collections::HashSet;
 
 use bytes::{BufMut as _, BytesMut};
-use futures::stream::FuturesUnordered;
 use futures::TryStreamExt as _;
+use futures::stream::FuturesUnordered;
 use tokio::io::{AsyncRead, AsyncReadExt as _, AsyncWrite, AsyncWriteExt as _};
 use tokio_util::codec::{Encoder, FramedRead};
 use tokio_util::compat::FuturesAsyncReadCompatExt as _;

--- a/crates/wasmtime/src/lib.rs
+++ b/crates/wasmtime/src/lib.rs
@@ -19,10 +19,10 @@ use tokio_util::codec::Encoder;
 use tracing::{debug, instrument, trace, warn};
 use uuid::Uuid;
 use wasmtime::component::{
-    types, Func, Resource, ResourceAny, ResourceTable, ResourceType, Type, Val,
+    Func, Resource, ResourceAny, ResourceTable, ResourceType, Type, Val, types,
 };
 use wasmtime::error::Context as _;
-use wasmtime::{bail, AsContextMut, Engine};
+use wasmtime::{AsContextMut, Engine, bail};
 use wrpc_transport::Invoke;
 
 use crate::bindings::rpc::context::Context;
@@ -124,12 +124,12 @@ pub trait WrpcViewExt: WrpcView {
     fn push_invocation(
         &mut self,
         invocation: impl Future<
-                Output = anyhow::Result<(
-                    <Self::Invoke as Invoke>::Outgoing,
-                    <Self::Invoke as Invoke>::Incoming,
-                )>,
-            > + Send
-            + 'static,
+            Output = anyhow::Result<(
+                <Self::Invoke as Invoke>::Outgoing,
+                <Self::Invoke as Invoke>::Incoming,
+            )>,
+        > + Send
+        + 'static,
     ) -> wasmtime::Result<Resource<Invocation>> {
         self.wrpc()
             .table
@@ -463,7 +463,7 @@ where
         _ => {
             return Err(CallError::TypeMismatch(wasmtime::Error::msg(
                 "RPC result type mismatch",
-            )))
+            )));
         }
     }
 

--- a/crates/wasmtime/src/paths.rs
+++ b/crates/wasmtime/src/paths.rs
@@ -15,9 +15,9 @@
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::sync::Arc;
 
-use wasmtime::component::types::{self, Type};
-use wasmtime::component::ResourceType;
 use wasmtime::Engine;
+use wasmtime::component::ResourceType;
+use wasmtime::component::types::{self, Type};
 
 /// Collect the (uninstantiated) resource types of the component's imported
 /// `wasi:io/streams` `input-stream` and `output-stream`, against which

--- a/crates/wasmtime/src/polyfill.rs
+++ b/crates/wasmtime/src/polyfill.rs
@@ -10,14 +10,14 @@ use tokio::io::AsyncWriteExt as _;
 use tokio::time::Instant;
 use tokio::try_join;
 use tokio_util::codec::Encoder;
-use tracing::{debug, instrument, trace, warn, Instrument as _, Span};
-use wasmtime::component::{types, LinkerInstance, ResourceType, Type, Val};
+use tracing::{Instrument as _, Span, debug, instrument, trace, warn};
+use wasmtime::component::{LinkerInstance, ResourceType, Type, Val, types};
 use wasmtime::error::Context as _;
-use wasmtime::{bail, ensure, AsContextMut, Engine, StoreContextMut};
+use wasmtime::{AsContextMut, Engine, StoreContextMut, bail, ensure};
 use wrpc_transport::{Index as _, Invoke, InvokeExt as _};
 
 use crate::rpc::Error;
-use crate::{read_value, rpc_func_name, rpc_result_type, ValEncoder, WrpcView, WrpcViewExt as _};
+use crate::{ValEncoder, WrpcView, WrpcViewExt as _, read_value, rpc_func_name, rpc_result_type};
 
 /// Polyfill [`types::ComponentItem`] in a [`LinkerInstance`] using [`wrpc_transport::Invoke`]
 #[instrument(level = "trace", skip_all)]
@@ -171,7 +171,7 @@ async fn invoke<T: WrpcView>(
         Err(err) => {
             return Ok(Err(err.context(format!(
                 "failed to invoke `{instance}.{name}` polyfill via wRPC"
-            ))))
+            ))));
         }
     };
     let tx = async {

--- a/crates/wasmtime/src/rpc/mod.rs
+++ b/crates/wasmtime/src/rpc/mod.rs
@@ -15,7 +15,7 @@ use wasmtime::error::Context as _;
 use wasmtime_wasi::p2::Pollable;
 use wrpc_transport::Invoke;
 
-use crate::{bindings, WrpcView};
+use crate::{WrpcView, bindings};
 
 mod host;
 

--- a/crates/wasmtime/src/serve.rs
+++ b/crates/wasmtime/src/serve.rs
@@ -6,13 +6,13 @@ use std::{collections::HashMap, sync::Arc};
 use anyhow::Context as _;
 use futures::{Stream, TryStreamExt as _};
 use tokio::sync::Mutex;
-use tracing::{debug, instrument, Instrument as _, Span};
+use tracing::{Instrument as _, Span, debug, instrument};
+use wasmtime::AsContextMut;
 use wasmtime::component::types;
 use wasmtime::component::{Instance, InstancePre, ResourceType};
-use wasmtime::AsContextMut;
 use wasmtime_wasi::WasiView;
 
-use crate::{call, rpc_func_name, WrpcView};
+use crate::{WrpcView, call, rpc_func_name};
 
 pub trait ServeExt: wrpc_transport::Serve {
     /// Serve [`types::ComponentFunc`] from an [`InstancePre`] instantiating it on each call.
@@ -31,12 +31,12 @@ pub trait ServeExt: wrpc_transport::Serve {
     ) -> impl Future<
         Output = anyhow::Result<
             impl Stream<
-                    Item = anyhow::Result<(
-                        Self::Context,
-                        Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'static>>,
-                    )>,
-                > + Send
-                + 'static,
+                Item = anyhow::Result<(
+                    Self::Context,
+                    Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'static>>,
+                )>,
+            > + Send
+            + 'static,
         >,
     > + Send
     where
@@ -136,12 +136,12 @@ pub trait ServeExt: wrpc_transport::Serve {
     ) -> impl Future<
         Output = anyhow::Result<
             impl Stream<
-                    Item = anyhow::Result<(
-                        Self::Context,
-                        Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'static>>,
-                    )>,
-                > + Send
-                + 'static,
+                Item = anyhow::Result<(
+                    Self::Context,
+                    Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'static>>,
+                )>,
+            > + Send
+            + 'static,
         >,
     > + Send
     where

--- a/crates/wave/src/core/decode.rs
+++ b/crates/wave/src/core/decode.rs
@@ -26,7 +26,7 @@ use std::pin::Pin;
 
 use tokio::io::{AsyncRead, AsyncReadExt as _};
 use wasm_tokio::{
-    cm::AsyncReadValue as _, AsyncReadCore as _, AsyncReadLeb128 as _, AsyncReadUtf8 as _,
+    AsyncReadCore as _, AsyncReadLeb128 as _, AsyncReadUtf8 as _, cm::AsyncReadValue as _,
 };
 use wasm_wave::value::{Type, Value};
 use wasm_wave::wasm::{WasmType, WasmTypeKind, WasmValue as _};

--- a/crates/wave/src/core/encode.rs
+++ b/crates/wave/src/core/encode.rs
@@ -5,7 +5,7 @@ use core::ops::{BitOrAssign, Shl};
 
 use std::collections::HashSet;
 
-use anyhow::{bail, Context as _};
+use anyhow::{Context as _, bail};
 use bytes::{BufMut as _, BytesMut};
 use tokio_util::codec::Encoder;
 use tracing::instrument;

--- a/crates/wave/src/sync/decode.rs
+++ b/crates/wave/src/sync/decode.rs
@@ -18,7 +18,7 @@
 
 use std::io::Cursor;
 
-use anyhow::{bail, Context as _};
+use anyhow::{Context as _, bail};
 use futures::executor::block_on;
 use wasm_wave::value::{Type, Value};
 

--- a/crates/websockets/src/lib.rs
+++ b/crates/websockets/src/lib.rs
@@ -1,7 +1,7 @@
 //! wRPC WebSocket transport using [tokio_websockets]
 
 use core::pin::Pin;
-use core::task::{ready, Context, Poll};
+use core::task::{Context, Poll, ready};
 
 use anyhow::Context as _;
 use bytes::Bytes;
@@ -13,8 +13,8 @@ use tokio_websockets::resolver::{Gai, Resolver};
 use tokio_websockets::{Message, WebSocketStream};
 use tracing::instrument;
 
-use wrpc_transport::frame::invoke;
 use wrpc_transport::Invoke;
+use wrpc_transport::frame::invoke;
 
 pub use tokio_websockets;
 #[doc(no_inline)]
@@ -86,7 +86,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Stream for Incoming<T> {
                     return Poll::Ready(Some(Err(std::io::Error::new(
                         std::io::ErrorKind::UnexpectedEof,
                         "WebSocket connection closed before EOF sentinel",
-                    ))))
+                    ))));
                 }
                 Some(Ok(msg)) if msg.is_ping() || msg.is_pong() => continue,
                 Some(Ok(msg)) => return Poll::Ready(Some(Ok(Bytes::from(msg.into_payload())))),

--- a/crates/websockets/tests/loopback.rs
+++ b/crates/websockets/tests/loopback.rs
@@ -1,6 +1,6 @@
 use anyhow::Context as _;
 use wrpc_transport::frame::Server;
-use wrpc_websockets::{split, Client};
+use wrpc_websockets::{Client, split};
 
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn loopback() -> anyhow::Result<()> {

--- a/crates/webtransport/src/lib.rs
+++ b/crates/webtransport/src/lib.rs
@@ -6,8 +6,8 @@ use anyhow::Context as _;
 use bytes::Bytes;
 use quinn::VarInt;
 use tracing::{debug, error, trace, warn};
-use wrpc_transport::frame::{invoke, Incoming, Outgoing};
 use wrpc_transport::Invoke;
+use wrpc_transport::frame::{Incoming, Outgoing, invoke};
 use wtransport::{Connection, RecvStream, SendStream};
 
 /// WebTransport server with graceful stream shutdown handling
@@ -47,10 +47,10 @@ impl wrpc_transport::frame::ConnHandler<RecvStream, SendStream> for ConnHandler 
         } else {
             debug!("ingress successfully complete");
         }
-        if let Ok(code) = VarInt::from_u64(0x52e4a40fa8db) {
-            if let Err(err) = rx.quic_stream_mut().stop(code) {
-                debug!(?err, "failed to close incoming stream");
-            }
+        if let Ok(code) = VarInt::from_u64(0x52e4a40fa8db)
+            && let Err(err) = rx.quic_stream_mut().stop(code)
+        {
+            debug!(?err, "failed to close incoming stream");
         }
     }
 

--- a/crates/wit-bindgen-go/src/interface.rs
+++ b/crates/wit-bindgen-go/src/interface.rs
@@ -9,11 +9,11 @@ use wit_bindgen_core::wit_parser::{
     InterfaceId, Record, Resolve, Result_, Tuple, Type, TypeDefKind, TypeId, TypeOwner, Variant,
     World, WorldKey,
 };
-use wit_bindgen_core::{uwrite, uwriteln, Source, TypeInfo};
+use wit_bindgen_core::{Source, TypeInfo, uwrite, uwriteln};
 use wrpc_introspect::{async_paths_ty, is_list_of, is_tuple, is_ty, rpc_func_name};
 
 use crate::{
-    to_go_ident, to_package_ident, to_upper_camel_case, Deps, GoWrpc, Identifier, InterfaceName,
+    Deps, GoWrpc, Identifier, InterfaceName, to_go_ident, to_package_ident, to_upper_camel_case,
 };
 
 fn go_func_name(func: &Function) -> String {
@@ -80,7 +80,10 @@ fn go_func_name(func: &Function) -> String {
     }
 }
 
-pub fn flatten_ty<'a>(resolve: &'a Resolve, ty: &Type) -> impl Iterator<Item = Type> + 'a {
+pub fn flatten_ty<'a>(
+    resolve: &'a Resolve,
+    ty: &Type,
+) -> impl Iterator<Item = Type> + 'a + use<'a> {
     let mut ty = *ty;
     loop {
         if let Type::Id(id) = ty {
@@ -90,7 +93,7 @@ pub fn flatten_ty<'a>(resolve: &'a Resolve, ty: &Type) -> impl Iterator<Item = T
                     continue;
                 }
                 TypeDefKind::Tuple(ref t) => {
-                    return Box::new(t.types.iter().copied()) as Box<dyn Iterator<Item = _>>
+                    return Box::new(t.types.iter().copied()) as Box<dyn Iterator<Item = _>>;
                 }
                 _ => {}
             }
@@ -103,7 +106,7 @@ pub struct InterfaceGenerator<'a> {
     pub src: Source,
     pub(super) identifier: Identifier<'a>,
     pub in_import: bool,
-    pub(super) gen: &'a mut GoWrpc,
+    pub(super) r#gen: &'a mut GoWrpc,
     pub resolve: &'a Resolve,
     pub deps: Deps,
 }
@@ -2475,7 +2478,7 @@ impl InterfaceGenerator<'_> {
         let mut funcs_to_export = vec![];
 
         for func in funcs {
-            if self.gen.skip.contains(&func.name) {
+            if self.r#gen.skip.contains(&func.name) {
                 continue;
             }
 
@@ -2739,7 +2742,7 @@ func ServeInterface(s {wrpc}.Server, h Handler) (stop func() error, err error) {
         funcs: impl Iterator<Item = &'a Function>,
     ) {
         for func in funcs {
-            if self.gen.skip.contains(&func.name) {
+            if self.r#gen.skip.contains(&func.name) {
                 return;
             }
 
@@ -2994,9 +2997,9 @@ func ServeInterface(s {wrpc}.Server, h Handler) (stop func() error, err error) {
             self.deps,
         );
         let map = if self.in_import {
-            &mut self.gen.import_modules
+            &mut self.r#gen.import_modules
         } else {
-            &mut self.gen.export_modules
+            &mut self.r#gen.export_modules
         };
         map.push((module, module_path));
     }
@@ -3108,10 +3111,10 @@ func ServeInterface(s {wrpc}.Server, h Handler) (stop func() error, err error) {
     }
 
     fn type_path_with_name(&mut self, id: TypeId, name: String) -> String {
-        if let TypeOwner::Interface(id) = self.resolve.types[id].owner {
-            if let Some(path) = self.path_to_interface(id) {
-                return format!("{path}.{name}");
-            }
+        if let TypeOwner::Interface(id) = self.resolve.types[id].owner
+            && let Some(path) = self.path_to_interface(id)
+        {
+            return format!("{path}.{name}");
         }
         name
     }
@@ -3125,17 +3128,13 @@ func ServeInterface(s {wrpc}.Server, h Handler) (stop func() error, err error) {
                 | TypeDefKind::Handle(..) => {}
                 TypeDefKind::List(..) if result => {}
                 TypeDefKind::Tuple(Tuple { types }) if types.len() == 1 => {
-                    return self.nillable_ptr(&types[0], result, decl)
+                    return self.nillable_ptr(&types[0], result, decl);
                 }
                 TypeDefKind::Type(ty) => return self.nillable_ptr(ty, result, decl),
                 _ => return "",
             }
         }
-        if decl {
-            "*"
-        } else {
-            "&"
-        }
+        if decl { "*" } else { "&" }
     }
 
     fn print_nillable_ptr(&mut self, ty: &Type, result: bool, decl: bool) {
@@ -3220,12 +3219,12 @@ func ServeInterface(s {wrpc}.Server, h Handler) (stop func() error, err error) {
     }
 
     fn print_option(&mut self, ty: &Type, decl: bool) {
-        if let Type::Id(id) = ty {
-            if let TypeDefKind::List(t) = self.resolve.types[*id].kind {
-                // Go slices are pointer types
-                self.print_list(&t);
-                return;
-            }
+        if let Type::Id(id) = ty
+            && let TypeDefKind::List(t) = self.resolve.types[*id].kind
+        {
+            // Go slices are pointer types
+            self.print_list(&t);
+            return;
         }
         if decl {
             self.push_str("*");
@@ -3372,11 +3371,11 @@ func ServeInterface(s {wrpc}.Server, h Handler) (stop func() error, err error) {
             import_name,
             import_path,
             ..
-        } = &self.gen.interface_names[&interface];
-        if let Identifier::Interface(cur, _) = self.identifier {
-            if cur == interface {
-                return None;
-            }
+        } = &self.r#gen.interface_names[&interface];
+        if let Identifier::Interface(cur, _) = self.identifier
+            && cur == interface
+        {
+            return None;
         }
         Some(self.deps.import(import_name.clone(), import_path.clone()))
     }
@@ -3386,7 +3385,7 @@ func ServeInterface(s {wrpc}.Server, h Handler) (stop func() error, err error) {
     }
 
     fn info(&self, ty: TypeId) -> TypeInfo {
-        self.gen.types.get(ty)
+        self.r#gen.types.get(ty)
     }
 }
 

--- a/crates/wit-bindgen-go/src/lib.rs
+++ b/crates/wit-bindgen-go/src/lib.rs
@@ -1,5 +1,5 @@
 use crate::interface::InterfaceGenerator;
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use core::fmt::Display;
 use heck::{ToLowerCamelCase, ToSnakeCase, ToUpperCamelCase};
 use std::collections::{BTreeMap, HashMap, HashSet};
@@ -8,11 +8,10 @@ use std::io::{Read, Write};
 use std::mem;
 use std::process::{Command, Stdio};
 use wit_bindgen_core::{
-    uwrite, uwriteln,
+    Files, InterfaceGenerator as _, Source, Types, WorldGenerator, uwrite, uwriteln,
     wit_parser::{
         Function, InterfaceId, PackageId, Resolve, TypeId, World, WorldId, WorldItem, WorldKey,
     },
-    Files, InterfaceGenerator as _, Source, Types, WorldGenerator,
 };
 
 mod interface;
@@ -287,7 +286,7 @@ impl GoWrpc {
             identifier,
             src: Source::default(),
             in_import,
-            gen: self,
+            r#gen: self,
             resolve,
             deps: Deps {
                 map: BTreeMap::default(),
@@ -316,7 +315,9 @@ impl GoWrpc {
     ) -> Result<bool> {
         let with_name = resolve.name_world_key(name);
         let Some(remapping) = self.with.get(&with_name) else {
-            bail!("no remapping found for {with_name:?} - use `--generate-all` or `--with {with_name}=generate` to generate bindings for this interface");
+            bail!(
+                "no remapping found for {with_name:?} - use `--generate-all` or `--with {with_name}=generate` to generate bindings for this interface"
+            );
         };
 
         let entry = match remapping {
@@ -478,12 +479,12 @@ impl WorldGenerator for GoWrpc {
         let world = &resolve.worlds[world];
         // Specify that all imports/exports local to the world's package should be generated
         for (key, item) in world.imports.iter().chain(world.exports.iter()) {
-            if let WorldItem::Interface { id, .. } = item {
-                if resolve.interfaces[*id].package == world.package {
-                    let name = resolve.name_world_key(key);
-                    if self.with.get(&name).is_none() {
-                        self.with.insert(name, InterfaceGeneration::Generate);
-                    }
+            if let WorldItem::Interface { id, .. } = item
+                && resolve.interfaces[*id].package == world.package
+            {
+                let name = resolve.name_world_key(key);
+                if self.with.get(&name).is_none() {
+                    self.with.insert(name, InterfaceGeneration::Generate);
                 }
             }
         }
@@ -501,12 +502,12 @@ impl WorldGenerator for GoWrpc {
         _files: &mut Files,
     ) -> anyhow::Result<()> {
         self.interface_last_seen_as_import.insert(id, true);
-        let mut gen = self.interface(Identifier::Interface(id, name), resolve, true);
-        let (snake, module_path) = gen.start_append_submodule(name);
-        if gen.gen.name_interface(resolve, id, name, false)? {
+        let mut r#gen = self.interface(Identifier::Interface(id, name), resolve, true);
+        let (snake, module_path) = r#gen.start_append_submodule(name);
+        if r#gen.r#gen.name_interface(resolve, id, name, false)? {
             return Ok(());
         }
-        gen.types(id);
+        r#gen.types(id);
 
         let identifier = Identifier::Interface(id, name);
         let interface = &resolve.interfaces[id];
@@ -523,13 +524,13 @@ impl WorldGenerator for GoWrpc {
         } else {
             name
         };
-        gen.generate_imports(
+        r#gen.generate_imports(
             identifier,
             &instance,
             resolve.interfaces[id].functions.values(),
         );
 
-        gen.finish_append_submodule(&snake, module_path);
+        r#gen.finish_append_submodule(&snake, module_path);
         Ok(())
     }
 
@@ -542,7 +543,7 @@ impl WorldGenerator for GoWrpc {
     ) {
         self.import_funcs_called = true;
 
-        let mut gen = self.interface(Identifier::World(world), resolve, true);
+        let mut r#gen = self.interface(Identifier::World(world), resolve, true);
         let World {
             ref name, package, ..
         } = resolve.worlds[world];
@@ -551,14 +552,14 @@ impl WorldGenerator for GoWrpc {
         } else {
             name.to_string()
         };
-        gen.generate_imports(
+        r#gen.generate_imports(
             Identifier::World(world),
             &instance,
             funcs.iter().map(|(_, func)| *func),
         );
 
-        let src = gen.finish();
-        for (k, v) in gen.deps.map {
+        let src = r#gen.finish();
+        for (k, v) in r#gen.deps.map {
             self.deps.import(k, v);
         }
         self.src.push_str(&src);
@@ -572,17 +573,17 @@ impl WorldGenerator for GoWrpc {
         _files: &mut Files,
     ) -> Result<()> {
         self.interface_last_seen_as_import.insert(id, false);
-        let mut gen = self.interface(Identifier::Interface(id, name), resolve, false);
-        let (snake, module_path) = gen.start_append_submodule(name);
-        if gen.gen.name_interface(resolve, id, name, true)? {
+        let mut r#gen = self.interface(Identifier::Interface(id, name), resolve, false);
+        let (snake, module_path) = r#gen.start_append_submodule(name);
+        if r#gen.r#gen.name_interface(resolve, id, name, true)? {
             return Ok(());
         }
-        gen.types(id);
-        let exports = gen.generate_exports(
+        r#gen.types(id);
+        let exports = r#gen.generate_exports(
             Identifier::Interface(id, name),
             resolve.interfaces[id].functions.values(),
         );
-        gen.finish_append_submodule(&snake, module_path);
+        r#gen.finish_append_submodule(&snake, module_path);
         if exports {
             let InterfaceName {
                 import_name,
@@ -603,10 +604,10 @@ impl WorldGenerator for GoWrpc {
         funcs: &[(&str, &Function)],
         _files: &mut Files,
     ) -> Result<()> {
-        let mut gen = self.interface(Identifier::World(world), resolve, false);
-        let exports = gen.generate_exports(Identifier::World(world), funcs.iter().map(|f| f.1));
-        let src = gen.finish();
-        for (k, v) in gen.deps.map {
+        let mut r#gen = self.interface(Identifier::World(world), resolve, false);
+        let exports = r#gen.generate_exports(Identifier::World(world), funcs.iter().map(|f| f.1));
+        let src = r#gen.finish();
+        for (k, v) in r#gen.deps.map {
             self.deps.import(k, v);
         }
         self.src.push_str(&src);
@@ -623,12 +624,12 @@ impl WorldGenerator for GoWrpc {
         types: &[(&str, TypeId)],
         _files: &mut Files,
     ) {
-        let mut gen = self.interface(Identifier::World(world), resolve, true);
+        let mut r#gen = self.interface(Identifier::World(world), resolve, true);
         for (name, ty) in types {
-            gen.define_type(name, *ty);
+            r#gen.define_type(name, *ty);
         }
-        let src = gen.finish();
-        for (k, v) in gen.deps.map {
+        let src = r#gen.finish();
+        for (k, v) in r#gen.deps.map {
             self.deps.import(k, v);
         }
         self.src.push_str(&src);

--- a/crates/wit-bindgen-rust-macro/src/lib.rs
+++ b/crates/wit-bindgen-rust-macro/src/lib.rs
@@ -6,7 +6,7 @@ use std::sync::atomic::{AtomicUsize, Ordering::Relaxed};
 use syn::parse::{Error, Parse, ParseStream, Result};
 use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
-use syn::{braced, token, LitStr, Token};
+use syn::{LitStr, Token, braced, token};
 use wit_bindgen_core::wit_parser::{PackageId, Resolve, UnresolvedPackageGroup, WorldId};
 use wit_bindgen_wrpc_rust::{Opts, WithOption};
 

--- a/crates/wit-bindgen-rust/src/interface.rs
+++ b/crates/wit-bindgen-rust/src/interface.rs
@@ -1,6 +1,6 @@
 use crate::{
-    full_wit_type_name, int_repr, to_rust_ident, to_upper_camel_case, FnSig, Identifier,
-    InterfaceName, RustFlagsRepr, RustWrpc, TypeGeneration,
+    FnSig, Identifier, InterfaceName, RustFlagsRepr, RustWrpc, TypeGeneration, full_wit_type_name,
+    int_repr, to_rust_ident, to_upper_camel_case,
 };
 use heck::{ToKebabCase, ToShoutySnakeCase, ToUpperCamelCase};
 use std::collections::{BTreeMap, BTreeSet};
@@ -10,7 +10,7 @@ use wit_bindgen_core::wit_parser::{
     Case, Docs, Enum, Field, Flags, Function, FunctionKind, Handle, Int, InterfaceId, Record,
     Resolve, Result_, Tuple, Type, TypeDefKind, TypeId, TypeOwner, Variant, World, WorldKey,
 };
-use wit_bindgen_core::{dealias, uwrite, uwriteln, Source, TypeInfo};
+use wit_bindgen_core::{Source, TypeInfo, dealias, uwrite, uwriteln};
 use wrpc_introspect::{async_paths_ty, async_paths_tyid, is_ty, rpc_func_name};
 
 pub struct InterfaceGenerator<'a> {
@@ -845,21 +845,19 @@ pub fn serve_interface<'a, T: {wrpc_transport}::Serve>(
         // If we have a typedef of a string or a list and it is being borrowed,
         // the typedef is an alias for `String` or `Vec<T>`; borrow it as `&str`
         // or `&[T]` so callers don't need to create owned copies.
-        if !owned {
-            if let Type::Id(id) = ty {
-                let id = dealias(self.resolve, *id);
-                match &self.resolve.types[id].kind {
-                    TypeDefKind::Type(Type::String) => {
-                        self.push_str("&'a str");
-                        return;
-                    }
-                    TypeDefKind::List(element) => {
-                        let element = *element;
-                        self.print_list(&element, false, submodule);
-                        return;
-                    }
-                    _ => {}
+        if !owned && let Type::Id(id) = ty {
+            let id = dealias(self.resolve, *id);
+            match &self.resolve.types[id].kind {
+                TypeDefKind::Type(Type::String) => {
+                    self.push_str("&'a str");
+                    return;
                 }
+                TypeDefKind::List(element) => {
+                    let element = *element;
+                    self.print_list(&element, false, submodule);
+                    return;
+                }
+                _ => {}
             }
         }
 
@@ -898,13 +896,13 @@ pub fn serve_interface<'a, T: {wrpc_transport}::Serve>(
     }
 
     fn type_path_with_name(&self, id: TypeId, name: String, submodule: bool) -> String {
-        if let TypeOwner::Interface(id) = self.resolve.types[id].owner {
-            if let Some(path) = self.path_to_interface(id) {
-                if submodule {
-                    return format!("super::{path}::{name}");
-                } else {
-                    return format!("{path}::{name}");
-                }
+        if let TypeOwner::Interface(id) = self.resolve.types[id].owner
+            && let Some(path) = self.path_to_interface(id)
+        {
+            if submodule {
+                return format!("super::{path}::{name}");
+            } else {
+                return format!("{path}::{name}");
             }
         }
         if submodule {

--- a/crates/wit-bindgen-rust/src/lib.rs
+++ b/crates/wit-bindgen-rust/src/lib.rs
@@ -1,5 +1,5 @@
 use crate::interface::InterfaceGenerator;
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use heck::{ToSnakeCase, ToUpperCamelCase};
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt::{self, Write as _};
@@ -9,8 +9,8 @@ use wit_bindgen_core::wit_parser::{
     WorldId, WorldItem, WorldKey,
 };
 use wit_bindgen_core::{
-    dealias, name_package_module, uwrite, uwriteln, Files, InterfaceGenerator as _, Source, Types,
-    WorldGenerator,
+    Files, InterfaceGenerator as _, Source, Types, WorldGenerator, dealias, name_package_module,
+    uwrite, uwriteln,
 };
 
 mod interface;
@@ -507,12 +507,12 @@ impl WorldGenerator for RustWrpc {
         let world = &resolve.worlds[world];
         // Specify that all imports local to the world's package should be generated
         for (key, item) in world.imports.iter().chain(world.exports.iter()) {
-            if let WorldItem::Interface { id, .. } = item {
-                if resolve.interfaces[*id].package == world.package {
-                    let name = resolve.name_world_key(key);
-                    if self.with.get(&name).is_none() {
-                        self.with.insert(name, TypeGeneration::Generate);
-                    }
+            if let WorldItem::Interface { id, .. } = item
+                && resolve.interfaces[*id].package == world.package
+            {
+                let name = resolve.name_world_key(key);
+                if self.with.get(&name).is_none() {
+                    self.with.insert(name, TypeGeneration::Generate);
                 }
             }
         }

--- a/crates/wit-bindgen-test/src/config.rs
+++ b/crates/wit-bindgen-test/src/config.rs
@@ -28,8 +28,8 @@
 
 use anyhow::Context;
 use anyhow::Result;
-use serde::de::DeserializeOwned;
 use serde::Deserialize;
+use serde::de::DeserializeOwned;
 
 /// Configuration that can be placed at the top of runtime tests in source
 /// language files. This is currently language-agnostic.

--- a/crates/wit-bindgen-test/src/lib.rs
+++ b/crates/wit-bindgen-test/src/lib.rs
@@ -9,7 +9,7 @@
     clippy::nonminimal_bool
 )]
 
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{Context, Result, anyhow, bail};
 use clap::Parser;
 use rayon::prelude::*;
 use std::collections::{HashMap, HashSet};
@@ -947,10 +947,10 @@ impl fmt::Display for Kind {
 /// as it was already on disk.
 fn write_if_different(path: &Path, contents: impl AsRef<[u8]>) -> Result<bool> {
     let contents = contents.as_ref();
-    if let Ok(prev) = fs::read(path) {
-        if prev == contents {
-            return Ok(false);
-        }
+    if let Ok(prev) = fs::read(path)
+        && prev == contents
+    {
+        return Ok(false);
     }
 
     if let Some(parent) = path.parent() {

--- a/crates/wit-bindgen-test/src/rust.rs
+++ b/crates/wit-bindgen-test/src/rust.rs
@@ -1,5 +1,5 @@
 use crate::{Component, LanguageMethods, Runner, Test, Verify};
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use clap::Parser;
 use heck::ToSnakeCase;
 use std::collections::HashMap;

--- a/examples/rust/hello-nats-server/src/main.rs
+++ b/examples/rust/hello-nats-server/src/main.rs
@@ -2,8 +2,8 @@ use core::pin::pin;
 
 use anyhow::Context as _;
 use clap::Parser;
-use futures::stream::select_all;
 use futures::StreamExt as _;
+use futures::stream::select_all;
 use tokio::task::JoinSet;
 use tokio::{select, signal};
 use tracing::{debug, error, info, warn};
@@ -74,11 +74,11 @@ async fn main() -> anyhow::Result<()> {
                     Ok(fut) => {
                         debug!(instance, name, "invocation accepted");
                         tasks.spawn(async move {
-                            if let Err(err) = fut.await {
+                            match fut.await { Err(err) => {
                                 warn!(?err, "failed to handle invocation");
-                            } else {
+                            } _ => {
                                 info!(instance, name, "invocation successfully handled");
-                            }
+                            }}
                         });
                     }
                     Err(err) => {

--- a/examples/rust/hello-quic-client/src/main.rs
+++ b/examples/rust/hello-quic-client/src/main.rs
@@ -4,12 +4,12 @@ use anyhow::Context as _;
 use clap::Parser;
 use core::net::SocketAddr;
 use quinn::Endpoint;
-use quinn::{crypto::rustls::QuicClientConfig, ClientConfig};
+use quinn::{ClientConfig, crypto::rustls::QuicClientConfig};
 use rustls::{
+    DigitallySignedStruct, SignatureScheme,
     client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier},
     pki_types::{CertificateDer, ServerName, UnixTime},
     version::TLS13,
-    DigitallySignedStruct, SignatureScheme,
 };
 
 mod bindings {

--- a/examples/rust/hello-quic-server/src/main.rs
+++ b/examples/rust/hello-quic-server/src/main.rs
@@ -5,11 +5,11 @@ use std::sync::Arc;
 
 use anyhow::Context as _;
 use clap::Parser;
-use futures::stream::select_all;
 use futures::StreamExt as _;
+use futures::stream::select_all;
 use quinn::crypto::rustls::QuicServerConfig;
 use quinn::{Endpoint, ServerConfig};
-use rcgen::{generate_simple_self_signed, CertifiedKey};
+use rcgen::{CertifiedKey, generate_simple_self_signed};
 use rustls::pki_types::{CertificateDer, PrivatePkcs8KeyDer};
 use rustls::version::TLS13;
 use tokio::task::JoinSet;
@@ -134,11 +134,11 @@ async fn main() -> anyhow::Result<()> {
                     Ok(fut) => {
                         debug!(instance, name, "invocation accepted");
                         tasks.spawn(async move {
-                            if let Err(err) = fut.await {
+                            match fut.await { Err(err) => {
                                 warn!(?err, "failed to handle invocation");
-                            } else {
+                            } _ => {
                                 info!(instance, name, "invocation successfully handled");
-                            }
+                            }}
                         });
                     }
                     Err(err) => {

--- a/examples/rust/hello-tcp-server/src/main.rs
+++ b/examples/rust/hello-tcp-server/src/main.rs
@@ -5,8 +5,8 @@ use std::sync::Arc;
 
 use anyhow::Context as _;
 use clap::Parser;
-use futures::stream::select_all;
 use futures::StreamExt as _;
+use futures::stream::select_all;
 use tokio::task::JoinSet;
 use tokio::{select, signal};
 use tracing::{debug, error, info, warn};
@@ -83,11 +83,11 @@ async fn main() -> anyhow::Result<()> {
                     Ok(fut) => {
                         debug!(instance, name, "invocation accepted");
                         tasks.spawn(async move {
-                            if let Err(err) = fut.await {
+                            match fut.await { Err(err) => {
                                 warn!(?err, "failed to handle invocation");
-                            } else {
+                            } _ => {
                                 info!(instance, name, "invocation successfully handled");
-                            }
+                            }}
                         });
                     }
                     Err(err) => {

--- a/examples/rust/hello-unix-server/src/main.rs
+++ b/examples/rust/hello-unix-server/src/main.rs
@@ -5,8 +5,8 @@ use std::sync::Arc;
 
 use anyhow::Context as _;
 use clap::Parser;
-use futures::stream::select_all;
 use futures::StreamExt as _;
+use futures::stream::select_all;
 use tokio::task::JoinSet;
 use tokio::{fs, select, signal};
 use tracing::{debug, error, info, warn};
@@ -44,12 +44,12 @@ async fn main() -> anyhow::Result<()> {
 
     let Args { path } = Args::parse();
 
-    if let Some(dir) = path.parent() {
-        if !dir.exists() {
-            fs::create_dir_all(dir)
-                .await
-                .with_context(|| format!("failed to create `{}`", dir.display()))?
-        }
+    if let Some(dir) = path.parent()
+        && !dir.exists()
+    {
+        fs::create_dir_all(dir)
+            .await
+            .with_context(|| format!("failed to create `{}`", dir.display()))?
     }
     let lis = tokio::net::UnixListener::bind(&path)
         .with_context(|| format!("failed to bind Unix listener on `{}`", path.display()))?;
@@ -91,11 +91,11 @@ async fn main() -> anyhow::Result<()> {
                     Ok(fut) => {
                         debug!(instance, name, "invocation accepted");
                         tasks.spawn(async move {
-                            if let Err(err) = fut.await {
+                            match fut.await { Err(err) => {
                                 warn!(?err, "failed to handle invocation");
-                            } else {
+                            } _ => {
                                 info!(instance, name, "invocation successfully handled");
-                            }
+                            }}
                         });
                     }
                     Err(err) => {

--- a/examples/rust/hello-web-server/src/main.rs
+++ b/examples/rust/hello-web-server/src/main.rs
@@ -5,9 +5,9 @@ use std::sync::Arc;
 
 use anyhow::Context as _;
 use clap::Parser;
-use futures::stream::select_all;
 use futures::StreamExt as _;
-use rcgen::{generate_simple_self_signed, CertifiedKey};
+use futures::stream::select_all;
+use rcgen::{CertifiedKey, generate_simple_self_signed};
 use rustls::pki_types::{CertificateDer, PrivatePkcs8KeyDer};
 use rustls::version::TLS13;
 use tokio::task::JoinSet;
@@ -118,11 +118,11 @@ async fn main() -> anyhow::Result<()> {
                     Ok(fut) => {
                         debug!(instance, name, "invocation accepted");
                         tasks.spawn(async move {
-                            if let Err(err) = fut.await {
+                            match fut.await { Err(err) => {
                                 warn!(?err, "failed to handle invocation");
-                            } else {
+                            } _ => {
                                 info!(instance, name, "invocation successfully handled");
-                            }
+                            }}
                         });
                     }
                     Err(err) => {

--- a/examples/rust/streams-nats-client/src/main.rs
+++ b/examples/rust/streams-nats-client/src/main.rs
@@ -3,7 +3,7 @@ use core::time::Duration;
 use anyhow::Context as _;
 use bytes::Bytes;
 use clap::Parser;
-use futures::{stream, StreamExt as _};
+use futures::{StreamExt as _, stream};
 use tokio::{time, try_join};
 use tokio_stream::wrappers::IntervalStream;
 use tracing::debug;
@@ -17,7 +17,7 @@ mod bindings {
     });
 }
 
-use bindings::wrpc_examples::streams::handler::{echo, Req};
+use bindings::wrpc_examples::streams::handler::{Req, echo};
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]

--- a/examples/rust/streams-nats-server/src/main.rs
+++ b/examples/rust/streams-nats-server/src/main.rs
@@ -1,4 +1,4 @@
-use core::pin::{pin, Pin};
+use core::pin::{Pin, pin};
 
 use anyhow::Context as _;
 use bytes::Bytes;
@@ -86,11 +86,11 @@ async fn main() -> anyhow::Result<()> {
                     Ok(fut) => {
                         debug!(instance, name, "invocation accepted");
                         tasks.spawn(async move {
-                            if let Err(err) = fut.await {
+                            match fut.await { Err(err) => {
                                 warn!(?err, "failed to handle invocation");
-                            } else {
+                            } _ => {
                                 info!(instance, name, "invocation successfully handled");
-                            }
+                            }}
                         });
                     }
                     Err(err) => {

--- a/examples/rust/streams-quic-client/src/main.rs
+++ b/examples/rust/streams-quic-client/src/main.rs
@@ -5,13 +5,13 @@ use anyhow::Context as _;
 use bytes::Bytes;
 use clap::Parser;
 use core::net::SocketAddr;
-use futures::{stream, StreamExt as _};
-use quinn::{crypto::rustls::QuicClientConfig, ClientConfig, Endpoint};
+use futures::{StreamExt as _, stream};
+use quinn::{ClientConfig, Endpoint, crypto::rustls::QuicClientConfig};
 use rustls::{
+    DigitallySignedStruct, SignatureScheme,
     client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier},
     pki_types::{CertificateDer, ServerName, UnixTime},
     version::TLS13,
-    DigitallySignedStruct, SignatureScheme,
 };
 use tokio::{time, try_join};
 use tokio_stream::wrappers::IntervalStream;
@@ -25,7 +25,7 @@ mod bindings {
     });
 }
 
-use bindings::wrpc_examples::streams::handler::{echo, Req};
+use bindings::wrpc_examples::streams::handler::{Req, echo};
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]

--- a/examples/rust/streams-quic-server/src/main.rs
+++ b/examples/rust/streams-quic-server/src/main.rs
@@ -1,5 +1,5 @@
 use core::net::SocketAddr;
-use core::pin::{pin, Pin};
+use core::pin::{Pin, pin};
 
 use std::sync::Arc;
 
@@ -10,7 +10,7 @@ use futures::stream::select_all;
 use futures::{Stream, StreamExt as _};
 use quinn::crypto::rustls::QuicServerConfig;
 use quinn::{Endpoint, ServerConfig};
-use rcgen::{generate_simple_self_signed, CertifiedKey};
+use rcgen::{CertifiedKey, generate_simple_self_signed};
 use rustls::pki_types::{CertificateDer, PrivatePkcs8KeyDer};
 use rustls::version::TLS13;
 use tokio::task::JoinSet;
@@ -144,11 +144,11 @@ async fn main() -> anyhow::Result<()> {
                     Ok(fut) => {
                         debug!(instance, name, "invocation accepted");
                         tasks.spawn(async move {
-                            if let Err(err) = fut.await {
+                            match fut.await { Err(err) => {
                                 warn!(?err, "failed to handle invocation");
-                            } else {
+                            } _ => {
                                 info!(instance, name, "invocation successfully handled");
-                            }
+                            }}
                         });
                     }
                     Err(err) => {

--- a/examples/rust/streams-tcp-client/src/main.rs
+++ b/examples/rust/streams-tcp-client/src/main.rs
@@ -3,7 +3,7 @@ use core::time::Duration;
 use anyhow::Context as _;
 use bytes::Bytes;
 use clap::Parser;
-use futures::{stream, StreamExt as _};
+use futures::{StreamExt as _, stream};
 use tokio::{time, try_join};
 use tokio_stream::wrappers::IntervalStream;
 use tracing::debug;
@@ -16,7 +16,7 @@ mod bindings {
     });
 }
 
-use bindings::wrpc_examples::streams::handler::{echo, Req};
+use bindings::wrpc_examples::streams::handler::{Req, echo};
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]

--- a/examples/rust/streams-tcp-server/src/main.rs
+++ b/examples/rust/streams-tcp-server/src/main.rs
@@ -1,5 +1,5 @@
 use core::net::SocketAddr;
-use core::pin::{pin, Pin};
+use core::pin::{Pin, pin};
 
 use std::sync::Arc;
 
@@ -93,11 +93,11 @@ async fn main() -> anyhow::Result<()> {
                     Ok(fut) => {
                         debug!(instance, name, "invocation accepted");
                         tasks.spawn(async move {
-                            if let Err(err) = fut.await {
+                            match fut.await { Err(err) => {
                                 warn!(?err, "failed to handle invocation");
-                            } else {
+                            } _ => {
                                 info!(instance, name, "invocation successfully handled");
-                            }
+                            }}
                         });
                     }
                     Err(err) => {

--- a/examples/rust/streams-web-client/src/main.rs
+++ b/examples/rust/streams-web-client/src/main.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use anyhow::Context as _;
 use bytes::Bytes;
 use clap::Parser;
-use futures::{stream, StreamExt as _};
+use futures::{StreamExt as _, stream};
 use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
 use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
 use rustls::version::TLS13;
@@ -24,7 +24,7 @@ mod bindings {
     });
 }
 
-use bindings::wrpc_examples::streams::handler::{echo, Req};
+use bindings::wrpc_examples::streams::handler::{Req, echo};
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]

--- a/examples/rust/streams-web-server/src/main.rs
+++ b/examples/rust/streams-web-server/src/main.rs
@@ -1,5 +1,5 @@
 use core::net::SocketAddr;
-use core::pin::{pin, Pin};
+use core::pin::{Pin, pin};
 
 use std::sync::Arc;
 
@@ -8,7 +8,7 @@ use bytes::Bytes;
 use clap::Parser;
 use futures::stream::select_all;
 use futures::{Stream, StreamExt as _};
-use rcgen::{generate_simple_self_signed, CertifiedKey};
+use rcgen::{CertifiedKey, generate_simple_self_signed};
 use rustls::pki_types::{CertificateDer, PrivatePkcs8KeyDer};
 use rustls::version::TLS13;
 use tokio::task::JoinSet;
@@ -142,11 +142,11 @@ async fn main() -> anyhow::Result<()> {
                     Ok(fut) => {
                         debug!(instance, name, "invocation accepted");
                         tasks.spawn(async move {
-                            if let Err(err) = fut.await {
+                            match fut.await { Err(err) => {
                                 warn!(?err, "failed to handle invocation");
-                            } else {
+                            } _ => {
                                 info!(instance, name, "invocation successfully handled");
-                            }
+                            }}
                         });
                     }
                     Err(err) => {

--- a/examples/rust/wasi-keyvalue-component-client/src/main.rs
+++ b/examples/rust/wasi-keyvalue-component-client/src/main.rs
@@ -6,7 +6,7 @@ mod bindings {
     });
 }
 
-use anyhow::{ensure, Context as _};
+use anyhow::{Context as _, ensure};
 
 use bindings::wasi::keyvalue::store;
 

--- a/examples/rust/wasi-keyvalue-nats-client/src/main.rs
+++ b/examples/rust/wasi-keyvalue-nats-client/src/main.rs
@@ -1,4 +1,4 @@
-use anyhow::{ensure, Context as _};
+use anyhow::{Context as _, ensure};
 use bytes::Bytes;
 use clap::Parser;
 use url::Url;

--- a/examples/rust/wasi-keyvalue-nats-server/src/main.rs
+++ b/examples/rust/wasi-keyvalue-nats-server/src/main.rs
@@ -2,8 +2,8 @@ use core::pin::pin;
 
 use anyhow::Context as _;
 use clap::Parser;
-use futures::stream::select_all;
 use futures::StreamExt as _;
+use futures::stream::select_all;
 use tokio::task::JoinSet;
 use tokio::{select, signal};
 use tracing::{debug, error, info, warn};
@@ -57,11 +57,11 @@ async fn main() -> anyhow::Result<()> {
                     Ok(fut) => {
                         debug!(instance, name, "invocation accepted");
                         tasks.spawn(async move {
-                            if let Err(err) = fut.await {
+                            match fut.await { Err(err) => {
                                 warn!(?err, "failed to handle invocation");
-                            } else {
+                            } _ => {
                                 info!(instance, name, "invocation successfully handled");
-                            }
+                            }}
                         });
                     }
                     Err(err) => {

--- a/examples/rust/wasi-keyvalue-quic-client/src/main.rs
+++ b/examples/rust/wasi-keyvalue-quic-client/src/main.rs
@@ -1,16 +1,16 @@
 use std::sync::Arc;
 
-use anyhow::{ensure, Context as _};
+use anyhow::{Context as _, ensure};
 use bytes::Bytes;
 use clap::Parser;
 use core::net::SocketAddr;
 use quinn::Endpoint;
-use quinn::{crypto::rustls::QuicClientConfig, ClientConfig};
+use quinn::{ClientConfig, crypto::rustls::QuicClientConfig};
 use rustls::{
+    DigitallySignedStruct, SignatureScheme,
     client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier},
     pki_types::{CertificateDer, ServerName, UnixTime},
     version::TLS13,
-    DigitallySignedStruct, SignatureScheme,
 };
 use wrpc_wasi_keyvalue::wasi::keyvalue::store;
 

--- a/examples/rust/wasi-keyvalue-quic-server/src/main.rs
+++ b/examples/rust/wasi-keyvalue-quic-server/src/main.rs
@@ -5,11 +5,11 @@ use std::sync::Arc;
 
 use anyhow::Context as _;
 use clap::Parser;
-use futures::stream::select_all;
 use futures::StreamExt as _;
+use futures::stream::select_all;
 use quinn::crypto::rustls::QuicServerConfig;
 use quinn::{Endpoint, ServerConfig};
-use rcgen::{generate_simple_self_signed, CertifiedKey};
+use rcgen::{CertifiedKey, generate_simple_self_signed};
 use rustls::pki_types::{CertificateDer, PrivatePkcs8KeyDer};
 use rustls::version::TLS13;
 use tokio::task::JoinSet;
@@ -118,11 +118,11 @@ async fn main() -> anyhow::Result<()> {
                     Ok(fut) => {
                         debug!(instance, name, "invocation accepted");
                         tasks.spawn(async move {
-                            if let Err(err) = fut.await {
+                            match fut.await { Err(err) => {
                                 warn!(?err, "failed to handle invocation");
-                            } else {
+                            } _ => {
                                 info!(instance, name, "invocation successfully handled");
-                            }
+                            }}
                         });
                     }
                     Err(err) => {

--- a/examples/rust/wasi-keyvalue-tcp-client/src/main.rs
+++ b/examples/rust/wasi-keyvalue-tcp-client/src/main.rs
@@ -1,4 +1,4 @@
-use anyhow::{ensure, Context as _};
+use anyhow::{Context as _, ensure};
 use bytes::Bytes;
 use clap::Parser;
 use wrpc_wasi_keyvalue::wasi::keyvalue::store;

--- a/examples/rust/wasi-keyvalue-tcp-server/src/main.rs
+++ b/examples/rust/wasi-keyvalue-tcp-server/src/main.rs
@@ -4,8 +4,8 @@ use std::sync::Arc;
 
 use anyhow::Context as _;
 use clap::Parser;
-use futures::stream::select_all;
 use futures::StreamExt as _;
+use futures::stream::select_all;
 use tokio::task::JoinSet;
 use tokio::{select, signal};
 use tracing::{debug, error, info, warn};
@@ -65,11 +65,11 @@ async fn main() -> anyhow::Result<()> {
                     Ok(fut) => {
                         debug!(instance, name, "invocation accepted");
                         tasks.spawn(async move {
-                            if let Err(err) = fut.await {
+                            match fut.await { Err(err) => {
                                 warn!(?err, "failed to handle invocation");
-                            } else {
+                            } _ => {
                                 info!(instance, name, "invocation successfully handled");
-                            }
+                            }}
                         });
                     }
                     Err(err) => {

--- a/examples/rust/wasi-keyvalue-unix-server/src/main.rs
+++ b/examples/rust/wasi-keyvalue-unix-server/src/main.rs
@@ -5,8 +5,8 @@ use std::sync::Arc;
 
 use anyhow::Context as _;
 use clap::Parser;
-use futures::stream::select_all;
 use futures::StreamExt as _;
+use futures::stream::select_all;
 use tokio::task::JoinSet;
 use tokio::{fs, select, signal};
 use tracing::{debug, error, info, warn};
@@ -25,12 +25,12 @@ async fn main() -> anyhow::Result<()> {
 
     let Args { path } = Args::parse();
 
-    if let Some(dir) = path.parent() {
-        if !dir.exists() {
-            fs::create_dir_all(dir)
-                .await
-                .with_context(|| format!("failed to create `{}`", dir.display()))?
-        }
+    if let Some(dir) = path.parent()
+        && !dir.exists()
+    {
+        fs::create_dir_all(dir)
+            .await
+            .with_context(|| format!("failed to create `{}`", dir.display()))?
     }
     let lis = tokio::net::UnixListener::bind(&path)
         .with_context(|| format!("failed to bind Unix listener on `{}`", path.display()))?;
@@ -73,11 +73,11 @@ async fn main() -> anyhow::Result<()> {
                     Ok(fut) => {
                         debug!(instance, name, "invocation accepted");
                         tasks.spawn(async move {
-                            if let Err(err) = fut.await {
+                            match fut.await { Err(err) => {
                                 warn!(?err, "failed to handle invocation");
-                            } else {
+                            } _ => {
                                 info!(instance, name, "invocation successfully handled");
-                            }
+                            }}
                         });
                     }
                     Err(err) => {

--- a/examples/rust/wasi-keyvalue-web-server/src/main.rs
+++ b/examples/rust/wasi-keyvalue-web-server/src/main.rs
@@ -6,8 +6,8 @@ use std::sync::Arc;
 
 use anyhow::Context as _;
 use clap::Parser;
-use futures::stream::select_all;
 use futures::StreamExt as _;
+use futures::stream::select_all;
 use tokio::task::JoinSet;
 use tokio::{select, signal};
 use tracing::{debug, error, info, warn};
@@ -104,11 +104,11 @@ async fn main() -> anyhow::Result<()> {
                     Ok(fut) => {
                         debug!(instance, name, "invocation accepted");
                         tasks.spawn(async move {
-                            if let Err(err) = fut.await {
+                            match fut.await { Err(err) => {
                                 warn!(?err, "failed to handle invocation");
-                            } else {
+                            } _ => {
                                 info!(instance, name, "invocation successfully handled");
-                            }
+                            }}
                         });
                     }
                     Err(err) => {

--- a/examples/web/rust/src/main.rs
+++ b/examples/web/rust/src/main.rs
@@ -7,14 +7,14 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use anyhow::Context as _;
+use axum::Router;
 use axum::http::header::CONTENT_TYPE;
 use axum::response::Html;
 use axum::routing::get;
-use axum::Router;
 use bytes::Bytes;
 use clap::Parser;
-use futures::stream::select_all;
 use futures::StreamExt as _;
+use futures::stream::select_all;
 use quinn::crypto::rustls::QuicClientConfig;
 use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
 use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
@@ -293,7 +293,7 @@ impl<C: Send + Sync> store::Handler<C> for Handler {
             scheme => {
                 return Ok(Err(store::Error::Other(format!(
                     "unsupported scheme: {scheme}"
-                ))))
+                ))));
             }
         };
         let id = Uuid::now_v7();
@@ -379,7 +379,7 @@ impl<C: Send + Sync> store::HandlerBucket<C> for Handler {
         let res = match self.bucket(bucket).await? {
             Bucket::Mem(bucket) => return self.mem.set(cx, bucket.as_borrow(), key, value).await,
             Bucket::Redis(bucket) => {
-                return self.redis.set(cx, bucket.as_borrow(), key, value).await
+                return self.redis.set(cx, bucket.as_borrow(), key, value).await;
             }
             Bucket::Nats(bucket, wrpc) => {
                 wrpc_wasi_keyvalue::wasi::keyvalue::store::Bucket::set(
@@ -575,7 +575,7 @@ impl<C: Send + Sync> store::HandlerBucket<C> for Handler {
         let res = match self.bucket(bucket).await? {
             Bucket::Mem(bucket) => return self.mem.list_keys(cx, bucket.as_borrow(), cursor).await,
             Bucket::Redis(bucket) => {
-                return self.redis.list_keys(cx, bucket.as_borrow(), cursor).await
+                return self.redis.list_keys(cx, bucket.as_borrow(), cursor).await;
             }
             Bucket::Nats(bucket, wrpc) => {
                 wrpc_wasi_keyvalue::wasi::keyvalue::store::Bucket::list_keys(
@@ -717,11 +717,11 @@ export const PORT = "{port}"
                         Ok(fut) => {
                             debug!(instance, name, "invocation accepted");
                             tasks.spawn(async move {
-                                if let Err(err) = fut.await {
+                                match fut.await { Err(err) => {
                                     warn!(?err, "failed to handle invocation");
-                                } else {
+                                } _ => {
                                     info!(instance, name, "invocation successfully handled");
-                                }
+                                }}
                             });
                         }
                         Err(err) => {

--- a/src/bin/wit-bindgen-wrpc.rs
+++ b/src/bin/wit-bindgen-wrpc.rs
@@ -1,8 +1,8 @@
-use anyhow::{bail, Context, Error, Result};
+use anyhow::{Context, Error, Result, bail};
 use clap::Parser;
 use std::path::PathBuf;
 use std::str;
-use wit_bindgen_core::{wit_parser, Files, WorldGenerator};
+use wit_bindgen_core::{Files, WorldGenerator, wit_parser};
 use wit_parser::Resolve;
 
 /// Helper for passing VERSION to opt.
@@ -111,14 +111,15 @@ fn main() -> Result<()> {
                 // problem is directly.
                 if let (Ok(utf8_prev), Ok(utf8_contents)) =
                     (str::from_utf8(&prev), str::from_utf8(contents))
-                {
-                    if !utf8_prev
+                    && !utf8_prev
                         .chars()
                         .any(|c| c.is_control() && !matches!(c, '\n' | '\r' | '\t'))
-                        && utf8_prev.lines().eq(utf8_contents.lines())
-                    {
-                        bail!("{} differs only in line endings (CRLF vs. LF). If this is a text file, configure git to mark the file as `text eol=lf`.", dst.display());
-                    }
+                    && utf8_prev.lines().eq(utf8_contents.lines())
+                {
+                    bail!(
+                        "{} differs only in line endings (CRLF vs. LF). If this is a text file, configure git to mark the file as `text eol=lf`.",
+                        dst.display()
+                    );
                 }
                 // The contents are binary or there are other differences; just
                 // issue a generic error.

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,6 +1,6 @@
 use anyhow::Context;
 use bytes::Bytes;
-use futures::{stream, StreamExt as _};
+use futures::{StreamExt as _, stream};
 use tokio::join;
 use tracing::info;
 

--- a/tests/go.rs
+++ b/tests/go.rs
@@ -1,4 +1,4 @@
-use anyhow::{ensure, Context};
+use anyhow::{Context, ensure};
 use tokio::process::Command;
 use tracing::instrument;
 

--- a/tests/go.rs
+++ b/tests/go.rs
@@ -228,7 +228,7 @@ async fn go_bindgen() -> anyhow::Result<()> {
         let v = sync::with_enum(&client, None)
             .await
             .context("failed to call `wrpc-test:integration/sync.with-enum-tuple`")?;
-        ensure!(v == Foobar::Bar, "{v:?}",);
+        ensure!(v == Foobar::Bar, "{v:?}");
 
         server
             .start_kill()

--- a/tests/rust.rs
+++ b/tests/rust.rs
@@ -364,7 +364,7 @@ where
 
             impl<C: Send + Sync> bindings::Handler<C> for Component {
                 async fn f(&self, _cx: C, x: String) -> anyhow::Result<u32> {
-                    let stored = self.inner.read().await.as_ref().unwrap().to_string();
+                    let stored = self.inner.read().await.as_ref().unwrap().clone();
                     assert_eq!(stored, x);
                     Ok(42)
                 }
@@ -1097,7 +1097,7 @@ async fn rust_bindgen_quic_sync() -> anyhow::Result<()> {
                     let (tx, rx) = sc.accept_bi().await.expect("failed to accept connection");
                     srv.accept((), tx, rx)
                         .await
-                        .expect("failed to accept connection")
+                        .expect("failed to accept connection");
                 };
                 select! {
                     res = &mut fut => return res,
@@ -1127,7 +1127,7 @@ async fn rust_bindgen_quic_async() -> anyhow::Result<()> {
                 let (tx, rx) = sc.accept_bi().await.expect("failed to accept connection");
                 srv.accept((), tx, rx)
                     .await
-                    .expect("failed to accept connection")
+                    .expect("failed to accept connection");
             };
             select! {
                 res = &mut fut => return res,
@@ -1155,7 +1155,7 @@ async fn rust_dynamic_quic() -> anyhow::Result<()> {
                     let (tx, rx) = sc.accept_bi().await.expect("failed to accept connection");
                     srv.accept((), tx, rx)
                         .await
-                        .expect("failed to accept connection")
+                        .expect("failed to accept connection");
                 };
                 select! {
                     res = &mut fut => return res,
@@ -1187,7 +1187,7 @@ async fn rust_bindgen_webtransport_sync() -> anyhow::Result<()> {
                     let (tx, rx) = sc.accept_bi().await.expect("failed to accept connection");
                     srv.accept((), tx, rx)
                         .await
-                        .expect("failed to accept connection")
+                        .expect("failed to accept connection");
                 };
                 select! {
                     res = &mut fut => return res,
@@ -1221,7 +1221,7 @@ async fn rust_bindgen_webtransport_async() -> anyhow::Result<()> {
                 let (tx, rx) = sc.accept_bi().await.expect("failed to accept connection");
                 srv.accept((), tx, rx)
                     .await
-                    .expect("failed to accept connection")
+                    .expect("failed to accept connection");
             };
             select! {
                 res = &mut fut => return res,
@@ -1249,7 +1249,7 @@ async fn rust_dynamic_webtransport() -> anyhow::Result<()> {
                     let (tx, rx) = sc.accept_bi().await.expect("failed to accept connection");
                     srv.accept((), tx, rx)
                         .await
-                        .expect("failed to accept connection")
+                        .expect("failed to accept connection");
                 };
                 select! {
                     res = &mut fut => return res,
@@ -1281,7 +1281,7 @@ async fn accept_websockets(
     let (tx, rx) = wrpc_websockets::split(ws);
     srv.accept((), tx, rx)
         .await
-        .expect("failed to accept connection")
+        .expect("failed to accept connection");
 }
 
 #[cfg(feature = "websockets")]
@@ -1377,7 +1377,7 @@ async fn rust_bindgen_tcp_sync() -> anyhow::Result<()> {
             let (rx, tx) = stream.into_split();
             srv.accept((), tx, rx)
                 .await
-                .expect("failed to accept connection")
+                .expect("failed to accept connection");
         }
         .instrument(span.clone());
         select! {
@@ -1509,7 +1509,7 @@ async fn rust_bindgen_tcp_async() -> anyhow::Result<()> {
             let (rx, tx) = stream.into_split();
             srv.accept((), tx, rx)
                 .await
-                .expect("failed to accept connection")
+                .expect("failed to accept connection");
         }
         .instrument(span.clone());
         select! {
@@ -1545,7 +1545,7 @@ async fn rust_bindgen_uds_sync() -> anyhow::Result<()> {
             let (rx, tx) = stream.into_split();
             srv.accept((), tx, rx)
                 .await
-                .expect("failed to accept connection")
+                .expect("failed to accept connection");
         }
         .instrument(span.clone());
         select! {
@@ -1581,7 +1581,7 @@ async fn rust_bindgen_uds_async() -> anyhow::Result<()> {
             let (rx, tx) = stream.into_split();
             srv.accept((), tx, rx)
                 .await
-                .expect("failed to accept connection")
+                .expect("failed to accept connection");
         }
         .instrument(span.clone());
         select! {

--- a/tests/rust.rs
+++ b/tests/rust.rs
@@ -4,7 +4,7 @@ mod common;
 
 use core::future::Future;
 use core::net::Ipv6Addr;
-use core::pin::{pin, Pin};
+use core::pin::{Pin, pin};
 use core::str;
 use core::time::Duration;
 
@@ -13,12 +13,12 @@ use std::sync::Arc;
 use anyhow::Context;
 use bytes::Bytes;
 use common::assert_async;
-use futures::{stream, FutureExt as _, Stream, StreamExt as _, TryStreamExt as _};
+use futures::{FutureExt as _, Stream, StreamExt as _, TryStreamExt as _, stream};
 use tokio::io::split;
-use tokio::sync::{oneshot, RwLock};
+use tokio::sync::{RwLock, oneshot};
 use tokio::time::sleep;
 use tokio::{join, select, spawn, try_join};
-use tracing::{info, info_span, instrument, Instrument, Span};
+use tracing::{Instrument, Span, info, info_span, instrument};
 use wrpc_transport::frame::Oneshot;
 use wrpc_transport::{InvokeExt as _, ResourceBorrow, ResourceOwn, ServeExt as _};
 
@@ -1116,10 +1116,12 @@ async fn rust_bindgen_quic_sync() -> anyhow::Result<()> {
 async fn rust_bindgen_quic_async() -> anyhow::Result<()> {
     wrpc_test::with_quic(|cc, sc| async move {
         let srv = Arc::new(wrpc_quic::Server::new());
-        let mut fut = pin!(async {
-            assert_bindgen_async(Arc::new(wrpc_quic::Client::from(cc)), Arc::clone(&srv)).await
-        }
-        .in_current_span());
+        let mut fut = pin!(
+            async {
+                assert_bindgen_async(Arc::new(wrpc_quic::Client::from(cc)), Arc::clone(&srv)).await
+            }
+            .in_current_span()
+        );
         loop {
             let accept = async {
                 let (tx, rx) = sc.accept_bi().await.expect("failed to accept connection");
@@ -1204,14 +1206,16 @@ async fn rust_bindgen_webtransport_sync() -> anyhow::Result<()> {
 async fn rust_bindgen_webtransport_async() -> anyhow::Result<()> {
     wrpc_test::with_webtransport(|cc, sc| async move {
         let srv = Arc::new(wrpc_webtransport::Server::new());
-        let mut fut = pin!(async {
-            assert_bindgen_async(
-                Arc::new(wrpc_webtransport::Client::from(cc)),
-                Arc::clone(&srv),
-            )
-            .await
-        }
-        .in_current_span());
+        let mut fut = pin!(
+            async {
+                assert_bindgen_async(
+                    Arc::new(wrpc_webtransport::Client::from(cc)),
+                    Arc::clone(&srv),
+                )
+                .await
+            }
+            .in_current_span()
+        );
         loop {
             let accept = async {
                 let (tx, rx) = sc.accept_bi().await.expect("failed to accept connection");
@@ -1356,14 +1360,16 @@ async fn rust_bindgen_tcp_sync() -> anyhow::Result<()> {
 
     let srv = Arc::new(wrpc_transport::frame::Server::default());
     let span = Span::current();
-    let mut fut = pin!(async {
-        assert_bindgen_sync(
-            Arc::new(wrpc_transport::frame::tcp::Client::from(addr)),
-            Arc::clone(&srv),
-        )
-        .await
-    }
-    .instrument(span.clone()));
+    let mut fut = pin!(
+        async {
+            assert_bindgen_sync(
+                Arc::new(wrpc_transport::frame::tcp::Client::from(addr)),
+                Arc::clone(&srv),
+            )
+            .await
+        }
+        .instrument(span.clone())
+    );
     loop {
         let accept = async {
             let (stream, addr) = lis.accept().await.expect("failed to accept connection");


### PR DESCRIPTION
Bump `workspace.package.edition` to 2024 and apply the mechanical migration produced by `cargo fix --edition` across all crates and examples. Also collapse nested `if let` into let-chains where clippy's `collapsible_if` now fires under 2024 (CI denies warnings), keeping the wit-bindgen subtree and the rest of the workspace clippy-clean.

Assisted-by: claude:claude-opus-4-8