### PR TITLE
fix(wit-bindgen-rust): derive async-func names from item_name

### DIFF
--- a/crates/wit-bindgen-rust/src/interface.rs
+++ b/crates/wit-bindgen-rust/src/interface.rs
@@ -326,7 +326,9 @@ pub fn serve_interface<'a, T: {wrpc_transport}::Serve>(
                             ::std::boxed::Box::pin(async move {{"
             );
             let (trait_name, name) = match func.kind {
-                FunctionKind::Freestanding | FunctionKind::AsyncFreestanding => ("Handler", name),
+                FunctionKind::Freestanding | FunctionKind::AsyncFreestanding => {
+                    ("Handler", to_rust_ident(func.item_name()).to_string())
+                }
                 FunctionKind::Method(id)
                 | FunctionKind::Constructor(id)
                 | FunctionKind::Static(id)
@@ -803,7 +805,7 @@ pub fn serve_interface<'a, T: {wrpc_transport}::Serve>(
                 self.push_str(&to_rust_ident(func.item_name()));
             }
         } else {
-            self.push_str(&to_rust_ident(&func.name));
+            self.push_str(&to_rust_ident(func.item_name()));
         };
         if self.in_import {
             uwrite!(

--- a/tests/codegen/async-resource.wit
+++ b/tests/codegen/async-resource.wit
@@ -1,0 +1,28 @@
+//@ async = true
+
+package my:async-resource;
+
+interface i {
+  f: async func();
+  one-argument: async func(x: u32);
+  one-result: async func() -> u32;
+  one-argument-and-result: async func(x: u32) -> u32;
+
+  resource r {
+    constructor();
+    method-no-args: async func();
+    method-one-argument: async func(x: u32);
+    method-one-result: async func() -> u32;
+    method-one-argument-and-result: async func(x: u32) -> u32;
+
+    static-no-args: static async func();
+    static-one-argument: static async func(x: u32);
+    static-one-result: static async func() -> u32;
+    static-one-argument-and-result: static async func(x: u32) -> u32;
+  }
+}
+
+world async-resource {
+  import i;
+  export i;
+}

--- a/tests/runtime/rust/async-modifier/runner.rs
+++ b/tests/runtime/rust/async-modifier/runner.rs
@@ -1,0 +1,11 @@
+use my::inline::i::{f, one_argument, one_argument_and_result, one_result};
+
+pub async fn run(
+    clt: &impl wit_bindgen_wrpc::wrpc_transport::Invoke<Context = ()>,
+) -> anyhow::Result<()> {
+    f(clt, ()).await?;
+    one_argument(clt, (), 1).await?;
+    assert_eq!(one_result(clt, ()).await?, 2);
+    assert_eq!(one_argument_and_result(clt, (), 3).await?, 4);
+    Ok(())
+}

--- a/tests/runtime/rust/async-modifier/test.rs
+++ b/tests/runtime/rust/async-modifier/test.rs
@@ -1,0 +1,19 @@
+#[derive(Clone)]
+pub struct Component;
+
+impl<Ctx: Send> exports::my::inline::i::Handler<Ctx> for Component {
+    async fn f(&self, _cx: Ctx) -> anyhow::Result<()> {
+        Ok(())
+    }
+    async fn one_argument(&self, _cx: Ctx, x: u32) -> anyhow::Result<()> {
+        assert_eq!(x, 1);
+        Ok(())
+    }
+    async fn one_result(&self, _cx: Ctx) -> anyhow::Result<u32> {
+        Ok(2)
+    }
+    async fn one_argument_and_result(&self, _cx: Ctx, x: u32) -> anyhow::Result<u32> {
+        assert_eq!(x, 3);
+        Ok(4)
+    }
+}

--- a/tests/runtime/rust/async-modifier/test.wit
+++ b/tests/runtime/rust/async-modifier/test.wit
@@ -1,0 +1,11 @@
+package my:inline;
+
+interface i {
+  f: async func();
+  one-argument: async func(x: u32);
+  one-result: async func() -> u32;
+  one-argument-and-result: async func(x: u32) -> u32;
+}
+
+world test { export i; }
+world runner { import i; }


### PR DESCRIPTION
wit-parser prefixes async functions in `func.name`: `[async]name`, `[async method]…`, `[async static]…`. Four generated names must agree for the stubs to compile: the client free-fn, the `Handler` trait method, the serve-dispatch `Handler::…` call, and the wire/rpc name.

For freestanding async funcs two of those sites derived the Rust identifier from the prefixed `func.name` via `to_rust_ident(&func.name)`, which falls through to `heck::to_snake_case` and turns `[async]one-argument` into `async_one_argument`:

- the client free-fn name (the `use_item_name == false` branch of `print_docs_and_params`), and
- the serve-dispatch `Handler::…` call (the freestanding arm reused the prefixed local `name`).

The `Handler` trait method and the wire name (`rpc_func_name`) already used the prefix-stripped item name, so for an `async func` the names drifted and the bindings failed to compile (E0432 on the client free-fn import, E0782 on the serve glue's `Handler::async_…` call). The `async func` modifier is meant to be a no-op in wRPC, where every func is already async over the transport.

Switch both sites to `func.item_name()` (identical to `func.name` for non-async functions), so all four names derive from the same prefix-stripped item name. Resource async methods/statics already used `item_name()` everywhere and were not affected; the internal `serve_interface` local bindings (`f_…`/`m_…`/`s_…`) keep deriving from `func.name` so same-named methods on different resources stay distinct.

The Go generator is unaffected: identifiers go through the centralized `go_func_name` and the wire name through `rpc_func_name`, both of which strip all prefixes.

Add regression coverage exercising the `async func` modifier:
- tests/runtime/rust/async-modifier: freestanding `async func`s exercised client↔server over the transport (fails to compile before this change).
- tests/codegen/async-resource.wit: compile-only coverage of `async func` freestanding plus `[async method]`/`[async static]`/constructor on a resource.

Assisted-by: claude:claude-opus-4-8