### PR TITLE
fix(go): emit a single stream terminator from stream encoders

### DIFF
--- a/crates/wit-bindgen-go/src/interface.rs
+++ b/crates/wit-bindgen-go/src/interface.rs
@@ -2206,36 +2206,38 @@ impl InterfaceGenerator<'_> {
                     if {math}.MaxUint32 - uint32(n) < total {{
                         return {errors}.New("total outgoing pending stream element count would overflow a 32-bit unsigned integer")
                     }}
-                    {slog}.Debug("writing pending stream chunk length", "len", n)
-                    _, err = {wrpc}.WriteUint32(uint32(n), w)
-                    if err != nil {{
-                        return {fmt}.Errorf("failed to write pending stream chunk length of %d: %w", n, err)
-                    }}
-                    for _, v := range chunk {{
-                        {slog}.Debug("writing pending stream element", "i", total)
-                        write, err :="#,
+                    if n > 0 {{
+                        {slog}.Debug("writing pending stream chunk length", "len", n)
+                        _, err = {wrpc}.WriteUint32(uint32(n), w)
+                        if err != nil {{
+                            return {fmt}.Errorf("failed to write pending stream chunk length of %d: %w", n, err)
+                        }}
+                        for _, v := range chunk {{
+                            {slog}.Debug("writing pending stream element", "i", total)
+                            write, err :="#,
                 );
                 self.print_write_ty(ty, "v", "w");
                 uwrite!(
                     self.src,
                     r#"
-                        if err != nil {{
-                            return {fmt}.Errorf("failed to write pending stream chunk element %d: %w", total, err)
-                        }}
-                        if write != nil {{
-                            wg.Add(1)
-                            w, err := w.Index(total)
                             if err != nil {{
-                                return {fmt}.Errorf("failed to index nested stream writer: %w", err)
+                                return {fmt}.Errorf("failed to write pending stream chunk element %d: %w", total, err)
                             }}
-                            go func() {{
-                                defer wg.Done()
-                                if err := write(w); err != nil {{
-                                    wgErr.Store(err)
+                            if write != nil {{
+                                wg.Add(1)
+                                w, err := w.Index(total)
+                                if err != nil {{
+                                    return {fmt}.Errorf("failed to index nested stream writer: %w", err)
                                 }}
-                            }}()
+                                go func() {{
+                                    defer wg.Done()
+                                    if err := write(w); err != nil {{
+                                        wgErr.Store(err)
+                                    }}
+                                }}()
+                            }}
+                            total++
                         }}
-                        total++
                     }}
                     if end {{
                         if err := w.WriteByte(0); err != nil {{

--- a/go/stream.go
+++ b/go/stream.go
@@ -42,14 +42,16 @@ func (v *ByteStreamWriter) WriteTo(w ByteWriter) (err error) {
 		if n > math.MaxUint32 {
 			return fmt.Errorf("pending byte stream chunk length of %d overflows a 32-bit integer", n)
 		}
-		slog.Debug("writing pending byte stream chunk length", "len", n)
-		_, err = WriteUint32(uint32(n), buf)
-		if err != nil {
-			return fmt.Errorf("failed to write pending byte stream chunk length of %d: %w", n, err)
-		}
-		_, err = buf.Write(v.chunk[:n])
-		if err != nil {
-			return fmt.Errorf("failed to write pending byte stream chunk contents: %w", err)
+		if n > 0 {
+			slog.Debug("writing pending byte stream chunk length", "len", n)
+			_, err = WriteUint32(uint32(n), buf)
+			if err != nil {
+				return fmt.Errorf("failed to write pending byte stream chunk length of %d: %w", n, err)
+			}
+			_, err = buf.Write(v.chunk[:n])
+			if err != nil {
+				return fmt.Errorf("failed to write pending byte stream chunk contents: %w", err)
+			}
 		}
 		if end {
 			if err := buf.WriteByte(0); err != nil {


### PR DESCRIPTION
The Go `stream<T>` encoder wrote the chunk length unconditionally on the EOF iteration, producing a zero-length (empty) chunk -- already a valid stream terminator -- and then also wrote an explicit end byte, emitting two terminators where the protocol expects one.

A decoder correctly terminates the stream on the first empty chunk and drops its sub-stream reader, so the redundant trailing byte then arrives for a sub-stream nobody is listening to. On the multiplexed framed transport this surfaced as a flaky `go_bindgen` failure under load: the surplus frame reached a closed receiver, which tore the whole connection down and truncated sibling streams.

Guard the chunk write with `if n > 0` so the encoder emits exactly one terminator (the explicit end byte), matching the byte-stream encoder and the decoders, which already terminate on an empty chunk. Apply the same guard to the runtime `ByteStreamWriter`, which also avoids a transient zero-length read prematurely terminating the stream.


Assisted-by: anthropic:claude-opus-4-8