### PR TITLE
refactor!: make framing mandatory and remove the `Index` trait

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -55,9 +55,9 @@ The indexing rules are as follows:
 
 ### Framing
 
-Transports provide a single bidirectional byte stream per wRPC invocation. wRPC defines a default framing format, described below, that multiplexes the asynchronous data streams of an invocation (each identified by its [index](#indexing)) over that single byte stream.
+Transports provide a single bidirectional byte stream per wRPC invocation. wRPC defines a mandatory framing format, described below, that multiplexes the asynchronous data streams of an invocation (each identified by its [index](#indexing)) over that single byte stream.
 
-All current wRPC transports (TCP, Unix Domain Sockets, QUIC, WebTransport and WebSockets) use this default framing. Individual transport implementations are free to use a custom framing instead, for example one built on a transport's native stream multiplexing.
+All wRPC transports use this framing. A transport implementation only needs to provide a single bidirectional byte stream; the framing layer supplies the multiplexing, so transports do not implement their own indexing scheme.
 
 ## Framed stream specification
 

--- a/crates/pack/src/lib.rs
+++ b/crates/pack/src/lib.rs
@@ -6,50 +6,9 @@
 //!
 //! This crate is maintained on a best-effort basis.
 
-use core::pin::Pin;
-use core::task::{Context, Poll};
-
 use bytes::BytesMut;
-use tokio::io::{AsyncRead, AsyncWrite};
 use tokio_util::codec::{Decoder, Encoder};
 use wrpc_transport::{Decode, Deferred as _, Encode};
-
-/// A stream, which fails on each operation, this type should only ever be used in trait bounds
-pub struct NoopStream;
-
-impl AsyncRead for NoopStream {
-    fn poll_read(
-        self: Pin<&mut Self>,
-        _: &mut Context<'_>,
-        _: &mut tokio::io::ReadBuf<'_>,
-    ) -> Poll<std::io::Result<()>> {
-        Poll::Ready(Err(std::io::Error::other("should not be called")))
-    }
-}
-
-impl AsyncWrite for NoopStream {
-    fn poll_write(
-        self: Pin<&mut Self>,
-        _: &mut Context<'_>,
-        _: &[u8],
-    ) -> Poll<std::io::Result<usize>> {
-        Poll::Ready(Err(std::io::Error::other("should not be called")))
-    }
-
-    fn poll_flush(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<std::io::Result<()>> {
-        Poll::Ready(Err(std::io::Error::other("should not be called")))
-    }
-
-    fn poll_shutdown(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<std::io::Result<()>> {
-        Poll::Ready(Err(std::io::Error::other("should not be called")))
-    }
-}
-
-impl wrpc_transport::Index<Self> for NoopStream {
-    fn index(&self, _: &[usize]) -> anyhow::Result<Self> {
-        anyhow::bail!("should not be called")
-    }
-}
 
 /// Pack a [`wrpc_transport::Encode`] into a singular byte buffer `dst`.
 ///
@@ -58,10 +17,7 @@ impl wrpc_transport::Index<Self> for NoopStream {
 ///
 /// This is unstable API, which will be deprecated once feature-complete "packing" functionality is available in [`wrpc_transport`].
 /// Track <https://github.com/bytecodealliance/wrpc/issues/25> for updates.
-pub fn pack<T: Encode<NoopStream>>(
-    v: T,
-    dst: &mut BytesMut,
-) -> Result<(), <T::Encoder as Encoder<T>>::Error> {
+pub fn pack<T: Encode>(v: T, dst: &mut BytesMut) -> Result<(), <T::Encoder as Encoder<T>>::Error> {
     let mut enc = T::Encoder::default();
     enc.encode(v, dst)?;
     if enc.take_deferred().is_some() {
@@ -82,9 +38,7 @@ pub fn pack<T: Encode<NoopStream>>(
 ///
 /// This is unstable API, which will be deprecated once feature-complete "unpacking" functionality is available in [`wrpc_transport`].
 /// Track <https://github.com/bytecodealliance/wrpc/issues/25> for updates.
-pub fn unpack<T: Decode<NoopStream>>(
-    buf: &mut BytesMut,
-) -> Result<T, <T::Decoder as Decoder>::Error> {
+pub fn unpack<T: Decode>(buf: &mut BytesMut) -> Result<T, <T::Decoder as Decoder>::Error> {
     let mut dec = T::Decoder::default();
     let v = dec.decode(buf)?;
     let v = v.ok_or_else(|| {

--- a/crates/quic/src/lib.rs
+++ b/crates/quic/src/lib.rs
@@ -63,8 +63,6 @@ impl From<Connection> for Client {
 
 impl Invoke for &Client {
     type Context = ();
-    type Outgoing = Outgoing;
-    type Incoming = Incoming;
 
     async fn invoke<P>(
         &self,
@@ -73,7 +71,7 @@ impl Invoke for &Client {
         func: &str,
         params: Bytes,
         paths: impl AsRef<[P]> + Send,
-    ) -> anyhow::Result<(Self::Outgoing, Self::Incoming)>
+    ) -> anyhow::Result<(Outgoing, Incoming)>
     where
         P: AsRef<[Option<usize>]> + Send + Sync,
     {
@@ -90,8 +88,6 @@ impl Invoke for &Client {
 
 impl Invoke for Client {
     type Context = ();
-    type Outgoing = Outgoing;
-    type Incoming = Incoming;
 
     async fn invoke<P>(
         &self,
@@ -100,7 +96,7 @@ impl Invoke for Client {
         func: &str,
         params: Bytes,
         paths: impl AsRef<[P]> + Send,
-    ) -> anyhow::Result<(Self::Outgoing, Self::Incoming)>
+    ) -> anyhow::Result<(Outgoing, Incoming)>
     where
         P: AsRef<[Option<usize>]> + Send + Sync,
     {

--- a/crates/test/src/lib.rs
+++ b/crates/test/src/lib.rs
@@ -18,7 +18,7 @@ use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
 use tokio::{select, spawn, try_join};
 use tracing::info;
-use wrpc_transport::{Index, Invoke, Serve};
+use wrpc_transport::{Invoke, Serve};
 
 async fn tcp_bind() -> anyhow::Result<TcpListener> {
     TcpListener::bind((Ipv6Addr::LOCALHOST, 0))

--- a/crates/transport/src/frame/conn/mod.rs
+++ b/crates/transport/src/frame/conn/mod.rs
@@ -19,8 +19,6 @@ use tokio_util::sync::PollSender;
 use tracing::{Instrument as _, Span, debug, error, instrument, trace};
 use wasm_tokio::{AsyncReadLeb128 as _, Leb128Encoder};
 
-use crate::Index;
-
 mod client;
 mod server;
 
@@ -293,9 +291,11 @@ pin_project! {
     }
 }
 
-impl Index<Self> for Incoming {
+impl Incoming {
+    /// Index the incoming stream using a structural `path`, returning a handle to the
+    /// multiplexed sub-stream addressed by it.
     #[instrument(level = "trace", skip(self), fields(path = ?self.path))]
-    fn index(&self, path: &[usize]) -> anyhow::Result<Self> {
+    pub fn index(&self, path: &[usize]) -> anyhow::Result<Self> {
         ensure!(!path.is_empty());
         let path = if self.path.is_empty() {
             Arc::from(path)
@@ -356,9 +356,11 @@ pin_project! {
     }
 }
 
-impl Index<Self> for Outgoing {
+impl Outgoing {
+    /// Index the outgoing stream using a structural `path`, returning a handle that writes
+    /// to the multiplexed sub-stream addressed by it.
     #[instrument(level = "trace", skip(self), fields(path = ?self.path))]
-    fn index(&self, path: &[usize]) -> anyhow::Result<Self> {
+    pub fn index(&self, path: &[usize]) -> anyhow::Result<Self> {
         ensure!(!path.is_empty());
         let path: Arc<[usize]> = if self.path.is_empty() {
             Arc::from(path)

--- a/crates/transport/src/frame/conn/mod.rs
+++ b/crates/transport/src/frame/conn/mod.rs
@@ -5,7 +5,6 @@ use core::task::{Context, Poll, ready};
 
 use std::sync::Arc;
 
-use anyhow::ensure;
 use bytes::{Buf as _, BufMut as _, Bytes, BytesMut};
 use futures::Sink as _;
 use pin_project_lite::pin_project;
@@ -295,8 +294,13 @@ impl Incoming {
     /// Index the incoming stream using a structural `path`, returning a handle to the
     /// multiplexed sub-stream addressed by it.
     #[instrument(level = "trace", skip(self), fields(path = ?self.path))]
-    pub fn index(&self, path: &[usize]) -> anyhow::Result<Self> {
-        ensure!(!path.is_empty());
+    pub fn index(&self, path: &[usize]) -> std::io::Result<Self> {
+        if path.is_empty() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "path cannot be empty",
+            ));
+        }
         let path = if self.path.is_empty() {
             Arc::from(path)
         } else {
@@ -360,8 +364,13 @@ impl Outgoing {
     /// Index the outgoing stream using a structural `path`, returning a handle that writes
     /// to the multiplexed sub-stream addressed by it.
     #[instrument(level = "trace", skip(self), fields(path = ?self.path))]
-    pub fn index(&self, path: &[usize]) -> anyhow::Result<Self> {
-        ensure!(!path.is_empty());
+    pub fn index(&self, path: &[usize]) -> std::io::Result<Self> {
+        if path.is_empty() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "path cannot be empty",
+            ));
+        }
         let path: Arc<[usize]> = if self.path.is_empty() {
             Arc::from(path)
         } else {

--- a/crates/transport/src/frame/conn/server.rs
+++ b/crates/transport/src/frame/conn/server.rs
@@ -161,8 +161,6 @@ where
     H: ConnHandler<I, O> + Send + Sync,
 {
     type Context = C;
-    type Outgoing = Outgoing;
-    type Incoming = Incoming;
 
     async fn serve(
         &self,
@@ -170,7 +168,7 @@ where
         func: &str,
         paths: Arc<[Box<[Option<usize>]>]>,
     ) -> anyhow::Result<
-        impl Stream<Item = anyhow::Result<(Self::Context, Self::Outgoing, Self::Incoming)>>
+        impl Stream<Item = anyhow::Result<(Self::Context, Outgoing, Incoming)>>
         + 'static
         + use<C, I, O, H>,
     > {
@@ -186,8 +184,6 @@ where
     H: ConnHandler<I, O> + Send + Sync,
 {
     type Context = C;
-    type Outgoing = Outgoing;
-    type Incoming = Incoming;
 
     async fn serve(
         &self,
@@ -195,7 +191,7 @@ where
         func: &str,
         paths: Arc<[Box<[Option<usize>]>]>,
     ) -> anyhow::Result<
-        impl Stream<Item = anyhow::Result<(Self::Context, Self::Outgoing, Self::Incoming)>>
+        impl Stream<Item = anyhow::Result<(Self::Context, Outgoing, Incoming)>>
         + 'static
         + use<'a, C, I, O, H>,
     > {

--- a/crates/transport/src/frame/oneshot.rs
+++ b/crates/transport/src/frame/oneshot.rs
@@ -58,8 +58,6 @@ where
     O: AsyncWrite + Send + Unpin + 'static,
 {
     type Context = ();
-    type Outgoing = Outgoing;
-    type Incoming = Incoming;
 
     async fn invoke<P>(
         &self,
@@ -68,7 +66,7 @@ where
         func: &str,
         params: Bytes,
         paths: impl AsRef<[P]> + Send,
-    ) -> anyhow::Result<(Self::Outgoing, Self::Incoming)>
+    ) -> anyhow::Result<(Outgoing, Incoming)>
     where
         P: AsRef<[Option<usize>]> + Send + Sync,
     {
@@ -82,8 +80,6 @@ where
     O: AsyncWrite + Send + Unpin + 'static,
 {
     type Context = ();
-    type Outgoing = Outgoing;
-    type Incoming = Incoming;
 
     #[instrument(level = "trace", skip(self, paths, params), fields(params = format!("{params:02x?}")))]
     fn invoke<P>(
@@ -93,7 +89,7 @@ where
         func: &str,
         params: Bytes,
         paths: impl AsRef<[P]> + Send,
-    ) -> impl Future<Output = anyhow::Result<(Self::Outgoing, Self::Incoming)>>
+    ) -> impl Future<Output = anyhow::Result<(Outgoing, Incoming)>>
     where
         P: AsRef<[Option<usize>]> + Send + Sync,
     {

--- a/crates/transport/src/frame/tcp/tokio.rs
+++ b/crates/transport/src/frame/tcp/tokio.rs
@@ -38,8 +38,6 @@ where
     T: ToSocketAddrs + Clone + Send + Sync,
 {
     type Context = ();
-    type Outgoing = Outgoing;
-    type Incoming = Incoming;
 
     #[instrument(level = "trace", skip(self, paths, params), fields(params = format!("{params:02x?}")))]
     async fn invoke<P>(
@@ -49,7 +47,7 @@ where
         func: &str,
         params: Bytes,
         paths: impl AsRef<[P]> + Send,
-    ) -> anyhow::Result<(Self::Outgoing, Self::Incoming)>
+    ) -> anyhow::Result<(Outgoing, Incoming)>
     where
         P: AsRef<[Option<usize>]> + Send + Sync,
     {
@@ -61,8 +59,6 @@ where
 
 impl Invoke for Invocation {
     type Context = ();
-    type Outgoing = Outgoing;
-    type Incoming = Incoming;
 
     #[instrument(level = "trace", skip(self, paths, params), fields(params = format!("{params:02x?}")))]
     async fn invoke<P>(
@@ -72,7 +68,7 @@ impl Invoke for Invocation {
         func: &str,
         params: Bytes,
         paths: impl AsRef<[P]> + Send,
-    ) -> anyhow::Result<(Self::Outgoing, Self::Incoming)>
+    ) -> anyhow::Result<(Outgoing, Incoming)>
     where
         P: AsRef<[Option<usize>]> + Send + Sync,
     {

--- a/crates/transport/src/frame/tcp/wasi.rs
+++ b/crates/transport/src/frame/tcp/wasi.rs
@@ -288,8 +288,6 @@ where
 
 impl Invoke for Client<&str, &Network> {
     type Context = mpsc::UnboundedSender<(Pollable, Waker)>;
-    type Outgoing = Outgoing;
-    type Incoming = Incoming;
 
     async fn invoke<P>(
         &self,
@@ -298,7 +296,7 @@ impl Invoke for Client<&str, &Network> {
         func: &str,
         params: Bytes,
         paths: impl AsRef<[P]> + Send,
-    ) -> anyhow::Result<(Self::Outgoing, Self::Incoming)>
+    ) -> anyhow::Result<(Outgoing, Incoming)>
     where
         P: AsRef<[Option<usize>]> + Send + Sync,
     {
@@ -317,8 +315,6 @@ impl Invoke for Client<&str, &Network> {
 
 impl Invoke for Client<&str, Network> {
     type Context = mpsc::UnboundedSender<(Pollable, Waker)>;
-    type Outgoing = Outgoing;
-    type Incoming = Incoming;
 
     async fn invoke<P>(
         &self,
@@ -327,7 +323,7 @@ impl Invoke for Client<&str, Network> {
         func: &str,
         params: Bytes,
         paths: impl AsRef<[P]> + Send,
-    ) -> anyhow::Result<(Self::Outgoing, Self::Incoming)>
+    ) -> anyhow::Result<(Outgoing, Incoming)>
     where
         P: AsRef<[Option<usize>]> + Send + Sync,
     {
@@ -346,8 +342,6 @@ impl Invoke for Client<&str, Network> {
 
 impl Invoke for Client<Box<str>, Network> {
     type Context = mpsc::UnboundedSender<(Pollable, Waker)>;
-    type Outgoing = Outgoing;
-    type Incoming = Incoming;
 
     async fn invoke<P>(
         &self,
@@ -356,7 +350,7 @@ impl Invoke for Client<Box<str>, Network> {
         func: &str,
         params: Bytes,
         paths: impl AsRef<[P]> + Send,
-    ) -> anyhow::Result<(Self::Outgoing, Self::Incoming)>
+    ) -> anyhow::Result<(Outgoing, Incoming)>
     where
         P: AsRef<[Option<usize>]> + Send + Sync,
     {
@@ -375,8 +369,6 @@ impl Invoke for Client<Box<str>, Network> {
 
 impl Invoke for Client<IpSocketAddress, &Network> {
     type Context = mpsc::UnboundedSender<(Pollable, Waker)>;
-    type Outgoing = Outgoing;
-    type Incoming = Incoming;
 
     async fn invoke<P>(
         &self,
@@ -385,7 +377,7 @@ impl Invoke for Client<IpSocketAddress, &Network> {
         func: &str,
         params: Bytes,
         paths: impl AsRef<[P]> + Send,
-    ) -> anyhow::Result<(Self::Outgoing, Self::Incoming)>
+    ) -> anyhow::Result<(Outgoing, Incoming)>
     where
         P: AsRef<[Option<usize>]> + Send + Sync,
     {
@@ -404,8 +396,6 @@ impl Invoke for Client<IpSocketAddress, &Network> {
 
 impl Invoke for Client<IpSocketAddress, Network> {
     type Context = mpsc::UnboundedSender<(Pollable, Waker)>;
-    type Outgoing = Outgoing;
-    type Incoming = Incoming;
 
     async fn invoke<P>(
         &self,
@@ -414,7 +404,7 @@ impl Invoke for Client<IpSocketAddress, Network> {
         func: &str,
         params: Bytes,
         paths: impl AsRef<[P]> + Send,
-    ) -> anyhow::Result<(Self::Outgoing, Self::Incoming)>
+    ) -> anyhow::Result<(Outgoing, Incoming)>
     where
         P: AsRef<[Option<usize>]> + Send + Sync,
     {

--- a/crates/transport/src/frame/unix.rs
+++ b/crates/transport/src/frame/unix.rs
@@ -60,8 +60,6 @@ impl From<std::os::unix::net::SocketAddr> for Client<std::os::unix::net::SocketA
 
 impl Invoke for Client<PathBuf> {
     type Context = ();
-    type Outgoing = Outgoing;
-    type Incoming = Incoming;
 
     #[instrument(level = "trace", skip(self, paths, params), fields(params = format!("{params:02x?}")))]
     async fn invoke<P>(
@@ -71,7 +69,7 @@ impl Invoke for Client<PathBuf> {
         func: &str,
         params: Bytes,
         paths: impl AsRef<[P]> + Send,
-    ) -> anyhow::Result<(Self::Outgoing, Self::Incoming)>
+    ) -> anyhow::Result<(Outgoing, Incoming)>
     where
         P: AsRef<[Option<usize>]> + Send + Sync,
     {
@@ -83,8 +81,6 @@ impl Invoke for Client<PathBuf> {
 
 impl Invoke for Client<&Path> {
     type Context = ();
-    type Outgoing = Outgoing;
-    type Incoming = Incoming;
 
     #[instrument(level = "trace", skip(self, paths, params), fields(params = format!("{params:02x?}")))]
     async fn invoke<P>(
@@ -94,7 +90,7 @@ impl Invoke for Client<&Path> {
         func: &str,
         params: Bytes,
         paths: impl AsRef<[P]> + Send,
-    ) -> anyhow::Result<(Self::Outgoing, Self::Incoming)>
+    ) -> anyhow::Result<(Outgoing, Incoming)>
     where
         P: AsRef<[Option<usize>]> + Send + Sync,
     {
@@ -106,8 +102,6 @@ impl Invoke for Client<&Path> {
 
 impl Invoke for Client<&std::os::unix::net::SocketAddr> {
     type Context = ();
-    type Outgoing = Outgoing;
-    type Incoming = Incoming;
 
     #[instrument(level = "trace", skip(self, paths, params), fields(params = format!("{params:02x?}")))]
     async fn invoke<P>(
@@ -117,7 +111,7 @@ impl Invoke for Client<&std::os::unix::net::SocketAddr> {
         func: &str,
         params: Bytes,
         paths: impl AsRef<[P]> + Send,
-    ) -> anyhow::Result<(Self::Outgoing, Self::Incoming)>
+    ) -> anyhow::Result<(Outgoing, Incoming)>
     where
         P: AsRef<[Option<usize>]> + Send + Sync,
     {
@@ -130,8 +124,6 @@ impl Invoke for Client<&std::os::unix::net::SocketAddr> {
 
 impl Invoke for Client<std::os::unix::net::SocketAddr> {
     type Context = ();
-    type Outgoing = Outgoing;
-    type Incoming = Incoming;
 
     #[instrument(level = "trace", skip(self, paths, params), fields(params = format!("{params:02x?}")))]
     async fn invoke<P>(
@@ -141,7 +133,7 @@ impl Invoke for Client<std::os::unix::net::SocketAddr> {
         func: &str,
         params: Bytes,
         paths: impl AsRef<[P]> + Send,
-    ) -> anyhow::Result<(Self::Outgoing, Self::Incoming)>
+    ) -> anyhow::Result<(Outgoing, Incoming)>
     where
         P: AsRef<[Option<usize>]> + Send + Sync,
     {

--- a/crates/transport/src/invoke.rs
+++ b/crates/transport/src/invoke.rs
@@ -8,23 +8,22 @@ use core::time::Duration;
 use anyhow::Context as _;
 use bytes::{Bytes, BytesMut};
 use futures::TryStreamExt as _;
-use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt as _};
+use tokio::io::AsyncWriteExt as _;
 use tokio::{select, try_join};
 use tokio_util::codec::{Encoder as _, FramedRead};
 use tracing::{Instrument as _, debug, instrument, trace};
 
-use crate::{Deferred as _, Incoming, Index, TupleDecode, TupleEncode};
+use crate::frame::{Incoming, Outgoing};
+use crate::{Deferred as _, TupleDecode, TupleEncode};
 
 /// Client-side handle to a wRPC transport
+///
+/// Invocations are always multiplexed over the wRPC framing layer, so the outgoing and
+/// incoming byte streams are the framed [`Outgoing`] and [`Incoming`] streams regardless of
+/// the underlying transport.
 pub trait Invoke: Send + Sync {
     /// Transport-specific invocation context
     type Context: Send + Sync;
-
-    /// Outgoing multiplexed byte stream
-    type Outgoing: AsyncWrite + Index<Self::Outgoing> + Send + Sync + Unpin + 'static;
-
-    /// Incoming multiplexed byte stream
-    type Incoming: AsyncRead + Index<Self::Incoming> + Send + Sync + Unpin + 'static;
 
     /// Invoke function `func` on instance `instance`
     fn invoke<P>(
@@ -34,7 +33,7 @@ pub trait Invoke: Send + Sync {
         func: &str,
         params: Bytes,
         paths: impl AsRef<[P]> + Send,
-    ) -> impl Future<Output = anyhow::Result<(Self::Outgoing, Self::Incoming)>> + Send
+    ) -> impl Future<Output = anyhow::Result<(Outgoing, Incoming)>> + Send
     where
         P: AsRef<[Option<usize>]> + Send + Sync;
 }
@@ -50,8 +49,6 @@ pub struct Timeout<'a, T: ?Sized> {
 
 impl<T: Invoke> Invoke for Timeout<'_, T> {
     type Context = T::Context;
-    type Outgoing = T::Outgoing;
-    type Incoming = T::Incoming;
 
     #[instrument(level = "trace", skip(self, cx, params, paths))]
     async fn invoke<P>(
@@ -61,7 +58,7 @@ impl<T: Invoke> Invoke for Timeout<'_, T> {
         func: &str,
         params: Bytes,
         paths: impl AsRef<[P]> + Send,
-    ) -> anyhow::Result<(Self::Outgoing, Self::Incoming)>
+    ) -> anyhow::Result<(Outgoing, Incoming)>
     where
         P: AsRef<[Option<usize>]> + Send + Sync,
     {
@@ -85,8 +82,6 @@ pub struct TimeoutOwned<T> {
 
 impl<T: Invoke> Invoke for TimeoutOwned<T> {
     type Context = T::Context;
-    type Outgoing = T::Outgoing;
-    type Incoming = T::Incoming;
 
     #[instrument(level = "trace", skip(self, cx, params, paths))]
     async fn invoke<P>(
@@ -96,7 +91,7 @@ impl<T: Invoke> Invoke for TimeoutOwned<T> {
         func: &str,
         params: Bytes,
         paths: impl AsRef<[P]> + Send,
-    ) -> anyhow::Result<(Self::Outgoing, Self::Incoming)>
+    ) -> anyhow::Result<(Outgoing, Incoming)>
     where
         P: AsRef<[Option<usize>]> + Send + Sync,
     {
@@ -132,8 +127,8 @@ pub trait InvokeExt: Invoke {
     where
         Paths: AsRef<[P]> + Send,
         P: AsRef<[Option<usize>]> + Send + Sync,
-        Params: TupleEncode<Self::Outgoing> + Send,
-        Results: TupleDecode<Self::Incoming> + Send,
+        Params: TupleEncode + Send,
+        Results: TupleDecode + Send,
         <Params::Encoder as tokio_util::codec::Encoder<Params>>::Error:
             std::error::Error + Send + Sync + 'static,
         <Results::Decoder as tokio_util::codec::Decoder>::Error:
@@ -194,7 +189,7 @@ pub trait InvokeExt: Invoke {
             trace!("received sync results");
             let buffer = mem::take(dec.read_buffer_mut());
             let rx = dec.decoder_mut().take_deferred();
-            let incoming = Incoming {
+            let incoming = crate::Incoming {
                 buffer,
                 inner: dec.into_inner(),
             };
@@ -248,8 +243,8 @@ pub trait InvokeExt: Invoke {
     ) -> impl Future<Output = anyhow::Result<Results>> + Send
     where
         P: AsRef<[Option<usize>]> + Send + Sync,
-        Params: TupleEncode<Self::Outgoing> + Send,
-        Results: TupleDecode<Self::Incoming> + Send,
+        Params: TupleEncode + Send,
+        Results: TupleDecode + Send,
         <Params::Encoder as tokio_util::codec::Encoder<Params>>::Error:
             std::error::Error + Send + Sync + 'static,
         <Results::Decoder as tokio_util::codec::Decoder>::Error:
@@ -331,7 +326,7 @@ mod tests {
         i: &T,
         cx: T::Context,
         paths: Arc<[Arc<[Option<usize>]>]>,
-    ) -> anyhow::Result<(T::Outgoing, T::Incoming)> {
+    ) -> anyhow::Result<(Outgoing, Incoming)> {
         i.invoke(cx, "foo", "bar", Bytes::default(), &paths).await
     }
 

--- a/crates/transport/src/invoke.rs
+++ b/crates/transport/src/invoke.rs
@@ -14,7 +14,7 @@ use tokio_util::codec::{Encoder as _, FramedRead};
 use tracing::{Instrument as _, debug, instrument, trace};
 
 use crate::frame::{Incoming, Outgoing};
-use crate::{Deferred as _, TupleDecode, TupleEncode};
+use crate::{BufferedIncoming, Deferred as _, TupleDecode, TupleEncode};
 
 /// Client-side handle to a wRPC transport
 ///
@@ -189,7 +189,7 @@ pub trait InvokeExt: Invoke {
             trace!("received sync results");
             let buffer = mem::take(dec.read_buffer_mut());
             let rx = dec.decoder_mut().take_deferred();
-            let incoming = crate::Incoming {
+            let incoming = BufferedIncoming {
                 buffer,
                 inner: dec.into_inner(),
             };

--- a/crates/transport/src/lib.rs
+++ b/crates/transport/src/lib.rs
@@ -53,12 +53,12 @@ impl<T: ?Sized> Captures<'_> for T {}
 ///
 /// This wraps the multiplexed framed [`frame::Incoming`] stream with a read buffer used to
 /// hold bytes that were read ahead while decoding synchronous values.
-pub struct Incoming {
+pub struct BufferedIncoming {
     buffer: BytesMut,
     inner: frame::Incoming,
 }
 
-impl Incoming {
+impl BufferedIncoming {
     /// Index the incoming stream using a structural `path`, returning a handle to the
     /// multiplexed sub-stream addressed by it.
     pub fn index(&self, path: &[usize]) -> anyhow::Result<Self> {
@@ -70,7 +70,7 @@ impl Incoming {
     }
 }
 
-impl AsyncRead for Incoming {
+impl AsyncRead for BufferedIncoming {
     fn poll_read(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,

--- a/crates/transport/src/lib.rs
+++ b/crates/transport/src/lib.rs
@@ -10,9 +10,11 @@
 //! - [Invoke] - the client-side handle to a wRPC transport, allowing clients to *invoke* WIT functions over wRPC transport
 //! - [Serve] - the server-side handle to a wRPC transport, allowing servers to *serve* WIT functions over wRPC transport
 //!
-//! Implementations of [Invoke] and [Serve] define transport-specific, multiplexed bidirectional byte stream types:
-//! - [`Invoke::Incoming`] and [`Serve::Incoming`] represent the stream *incoming* from a peer.
-//! - [`Invoke::Outgoing`] and [`Serve::Outgoing`] represent the stream *outgoing* to a peer.
+//! [Invoke] and [Serve] establish a single bidirectional byte stream per invocation, over which
+//! wRPC layers its [framing](frame) protocol to multiplex the nested async parameter and result
+//! sub-streams. Both therefore yield the framed [`frame::Outgoing`] and [`frame::Incoming`]
+//! streams regardless of the underlying transport, which only needs to provide any
+//! [`AsyncWrite`](tokio::io::AsyncWrite)/[`AsyncRead`](tokio::io::AsyncRead) byte stream.
 
 pub mod frame;
 pub mod invoke;
@@ -47,23 +49,19 @@ pub trait Captures<'a> {}
 
 impl<T: ?Sized> Captures<'_> for T {}
 
-/// Multiplexes streams
-///
-/// Implementations of this trait define multiplexing for underlying connections
-/// using a particular structural `path`
-pub trait Index<T> {
-    /// Index the entity using a structural `path`
-    fn index(&self, path: &[usize]) -> anyhow::Result<T>;
-}
-
 /// Buffered incoming stream used for decoding values
-pub struct Incoming<T> {
+///
+/// This wraps the multiplexed framed [`frame::Incoming`] stream with a read buffer used to
+/// hold bytes that were read ahead while decoding synchronous values.
+pub struct Incoming {
     buffer: BytesMut,
-    inner: T,
+    inner: frame::Incoming,
 }
 
-impl<T: Index<T>> Index<Self> for Incoming<T> {
-    fn index(&self, path: &[usize]) -> anyhow::Result<Self> {
+impl Incoming {
+    /// Index the incoming stream using a structural `path`, returning a handle to the
+    /// multiplexed sub-stream addressed by it.
+    pub fn index(&self, path: &[usize]) -> anyhow::Result<Self> {
         let inner = self.inner.index(path)?;
         Ok(Self {
             buffer: BytesMut::default(),
@@ -72,7 +70,7 @@ impl<T: Index<T>> Index<Self> for Incoming<T> {
     }
 }
 
-impl<T: AsyncRead + Unpin> AsyncRead for Incoming<T> {
+impl AsyncRead for Incoming {
     fn poll_read(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,

--- a/crates/transport/src/serve.rs
+++ b/crates/transport/src/serve.rs
@@ -13,7 +13,7 @@ use tokio_util::codec::{FramedRead, FramedWrite};
 use tracing::{Instrument as _, Span, debug, instrument, trace};
 
 use crate::frame::{Incoming, Outgoing};
-use crate::{Deferred as _, TupleDecode, TupleEncode};
+use crate::{BufferedIncoming, Deferred as _, TupleDecode, TupleEncode};
 
 /// Server-side handle to a wRPC transport
 ///
@@ -107,7 +107,7 @@ pub trait ServeExt: Serve {
                         params,
                         rx.map(|f| {
                             f(
-                                crate::Incoming {
+                                BufferedIncoming {
                                     buffer,
                                     inner: dec.into_inner(),
                                 },

--- a/crates/transport/src/serve.rs
+++ b/crates/transport/src/serve.rs
@@ -8,22 +8,21 @@ use std::sync::Arc;
 
 use anyhow::{Context as _, bail};
 use futures::{SinkExt as _, Stream, TryStreamExt as _};
-use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt as _};
+use tokio::io::AsyncWriteExt as _;
 use tokio_util::codec::{FramedRead, FramedWrite};
 use tracing::{Instrument as _, Span, debug, instrument, trace};
 
-use crate::{Deferred as _, Incoming, Index, TupleDecode, TupleEncode};
+use crate::frame::{Incoming, Outgoing};
+use crate::{Deferred as _, TupleDecode, TupleEncode};
 
 /// Server-side handle to a wRPC transport
+///
+/// Invocations are always multiplexed over the wRPC framing layer, so the outgoing and
+/// incoming byte streams are the framed [`Outgoing`] and [`Incoming`] streams regardless of
+/// the underlying transport.
 pub trait Serve: Sync {
     /// Transport-specific invocation context
     type Context: Send + Sync + 'static;
-
-    /// Outgoing multiplexed byte stream
-    type Outgoing: AsyncWrite + Index<Self::Outgoing> + Send + Sync + Unpin + 'static;
-
-    /// Incoming multiplexed byte stream
-    type Incoming: AsyncRead + Index<Self::Incoming> + Send + Sync + Unpin + 'static;
 
     /// Serve function `func` from instance `instance`
     fn serve(
@@ -33,7 +32,7 @@ pub trait Serve: Sync {
         paths: Arc<[Box<[Option<usize>]>]>,
     ) -> impl Future<
         Output = anyhow::Result<
-            impl Stream<Item = anyhow::Result<(Self::Context, Self::Outgoing, Self::Incoming)>>
+            impl Stream<Item = anyhow::Result<(Self::Context, Outgoing, Incoming)>>
             + Send
             + 'static
             + use<Self>,
@@ -78,8 +77,8 @@ pub trait ServeExt: Serve {
         >,
     > + Send
     where
-        Params: TupleDecode<Self::Incoming> + Send + 'static,
-        Results: TupleEncode<Self::Outgoing> + Send + 'static,
+        Params: TupleDecode + Send + 'static,
+        Results: TupleEncode + Send + 'static,
         <Params::Decoder as tokio_util::codec::Decoder>::Error:
             std::error::Error + Send + Sync + 'static,
         <Results::Encoder as tokio_util::codec::Encoder<Results>>::Error:
@@ -108,7 +107,7 @@ pub trait ServeExt: Serve {
                         params,
                         rx.map(|f| {
                             f(
-                                Incoming {
+                                crate::Incoming {
                                     buffer,
                                     inner: dec.into_inner(),
                                 },
@@ -161,9 +160,7 @@ mod tests {
 
     use super::*;
 
-    async fn call_serve<T: Serve>(
-        s: &T,
-    ) -> anyhow::Result<Vec<(T::Context, T::Outgoing, T::Incoming)>> {
+    async fn call_serve<T: Serve>(s: &T) -> anyhow::Result<Vec<(T::Context, Outgoing, Incoming)>> {
         let st = stream::empty()
             .chain({
                 s.serve(

--- a/crates/transport/src/value.rs
+++ b/crates/transport/src/value.rs
@@ -31,7 +31,7 @@ use wasm_tokio::{
     Leb128Encoder, Utf8Codec,
 };
 
-use crate::Incoming;
+use crate::BufferedIncoming;
 use crate::frame::Outgoing;
 
 /// Borrowed resource handle, represented as an opaque byte blob
@@ -381,7 +381,7 @@ macro_rules! impl_handle_deferred {
 }
 
 impl_handle_deferred!(handle_deferred_tx, Outgoing);
-impl_handle_deferred!(handle_deferred_rx, Incoming);
+impl_handle_deferred!(handle_deferred_rx, BufferedIncoming);
 
 /// Defines value encoding
 pub trait Encode: Sized {
@@ -505,7 +505,7 @@ pub trait Encode: Sized {
 pub trait Decode: Sized {
     /// Decoder used to decode value
     type Decoder: tokio_util::codec::Decoder<Item = Self>
-        + Deferred<Incoming>
+        + Deferred<BufferedIncoming>
         + Default
         + Send
         + 'static;
@@ -740,7 +740,7 @@ where
     dec: T,
     ret: Vec<T::Item>,
     cap: usize,
-    deferred: Vec<Option<DeferredFn<Incoming>>>,
+    deferred: Vec<Option<DeferredFn<BufferedIncoming>>>,
 }
 
 impl<T> ListDecoder<T>
@@ -767,11 +767,11 @@ where
     }
 }
 
-impl<T> Deferred<Incoming> for ListDecoder<T>
+impl<T> Deferred<BufferedIncoming> for ListDecoder<T>
 where
     T: tokio_util::codec::Decoder,
 {
-    fn take_deferred(&mut self) -> Option<DeferredFn<Incoming>> {
+    fn take_deferred(&mut self) -> Option<DeferredFn<BufferedIncoming>> {
         let deferred = mem::take(&mut self.deferred);
         if deferred.iter().any(Option::is_some) {
             Some(Box::new(|r, path| {
@@ -785,7 +785,7 @@ where
 
 impl<T> tokio_util::codec::Decoder for ListDecoder<T>
 where
-    T: tokio_util::codec::Decoder + Deferred<Incoming>,
+    T: tokio_util::codec::Decoder + Deferred<BufferedIncoming>,
 {
     type Item = Vec<T::Item>;
     type Error = T::Error;
@@ -821,7 +821,7 @@ where
 impl<T> Decode for Vec<T>
 where
     T: Decode + Send,
-    T::ListDecoder: Deferred<Incoming> + Send,
+    T::ListDecoder: Deferred<BufferedIncoming> + Send,
 {
     type Decoder = T::ListDecoder;
     type ListDecoder = ListDecoder<Self::Decoder>;
@@ -1250,14 +1250,14 @@ impl<T: ?Sized> Default for ResourceBorrowDecoder<T> {
     }
 }
 
-impl<T: ?Sized> Deferred<Incoming> for ResourceBorrowDecoder<T> {
-    fn take_deferred(&mut self) -> Option<DeferredFn<Incoming>> {
+impl<T: ?Sized> Deferred<BufferedIncoming> for ResourceBorrowDecoder<T> {
+    fn take_deferred(&mut self) -> Option<DeferredFn<BufferedIncoming>> {
         None
     }
 }
 
-impl<T: ?Sized> Deferred<Incoming> for CoreVecDecoder<ResourceBorrowDecoder<T>> {
-    fn take_deferred(&mut self) -> Option<DeferredFn<Incoming>> {
+impl<T: ?Sized> Deferred<BufferedIncoming> for CoreVecDecoder<ResourceBorrowDecoder<T>> {
+    fn take_deferred(&mut self) -> Option<DeferredFn<BufferedIncoming>> {
         None
     }
 }
@@ -1295,14 +1295,14 @@ impl<T: ?Sized> Default for ResourceOwnDecoder<T> {
     }
 }
 
-impl<T: ?Sized> Deferred<Incoming> for ResourceOwnDecoder<T> {
-    fn take_deferred(&mut self) -> Option<DeferredFn<Incoming>> {
+impl<T: ?Sized> Deferred<BufferedIncoming> for ResourceOwnDecoder<T> {
+    fn take_deferred(&mut self) -> Option<DeferredFn<BufferedIncoming>> {
         None
     }
 }
 
-impl<T: ?Sized> Deferred<Incoming> for CoreVecDecoder<ResourceOwnDecoder<T>> {
-    fn take_deferred(&mut self) -> Option<DeferredFn<Incoming>> {
+impl<T: ?Sized> Deferred<BufferedIncoming> for CoreVecDecoder<ResourceOwnDecoder<T>> {
+    fn take_deferred(&mut self) -> Option<DeferredFn<BufferedIncoming>> {
         None
     }
 }
@@ -1424,11 +1424,11 @@ macro_rules! impl_tuple_codec {
             type Encoder = TupleEncoder::<($($vt::Encoder),+,)>;
         }
 
-        impl<$($vt),+> Deferred<Incoming> for TupleDecoder::<($($vt::Decoder),+,), ($(Option<$vt>),+,)>
+        impl<$($vt),+> Deferred<BufferedIncoming> for TupleDecoder::<($($vt::Decoder),+,), ($(Option<$vt>),+,)>
         where
             $($vt: Decode),+
         {
-            fn take_deferred(&mut self) -> Option<DeferredFn<Incoming>> {
+            fn take_deferred(&mut self) -> Option<DeferredFn<BufferedIncoming>> {
                 let ($(mut $cn),+,) = mem::take(self).into_inner();
                 let deferred = [ $($cn.take_deferred()),+ ];
                 if deferred.iter().any(Option::is_some) {
@@ -1638,7 +1638,7 @@ where
     T: Decode,
 {
     dec: OptionDecoder<T::Decoder>,
-    deferred: Option<DeferredFn<Incoming>>,
+    deferred: Option<DeferredFn<BufferedIncoming>>,
     _ty: PhantomData<T>,
 }
 
@@ -1655,11 +1655,11 @@ where
     }
 }
 
-impl<T> Deferred<Incoming> for FutureDecoder<T>
+impl<T> Deferred<BufferedIncoming> for FutureDecoder<T>
 where
     T: Decode,
 {
-    fn take_deferred(&mut self) -> Option<DeferredFn<Incoming>> {
+    fn take_deferred(&mut self) -> Option<DeferredFn<BufferedIncoming>> {
         self.deferred.take()
     }
 }
@@ -2004,7 +2004,7 @@ where
     T: Decode,
 {
     dec: T::ListDecoder,
-    deferred: Option<DeferredFn<Incoming>>,
+    deferred: Option<DeferredFn<BufferedIncoming>>,
     _ty: PhantomData<T>,
 }
 
@@ -2021,11 +2021,11 @@ where
     }
 }
 
-impl<T> Deferred<Incoming> for StreamDecoder<T>
+impl<T> Deferred<BufferedIncoming> for StreamDecoder<T>
 where
     T: Decode,
 {
-    fn take_deferred(&mut self) -> Option<DeferredFn<Incoming>> {
+    fn take_deferred(&mut self) -> Option<DeferredFn<BufferedIncoming>> {
         self.deferred.take()
     }
 }
@@ -2033,12 +2033,12 @@ where
 #[instrument(level = "trace", skip(dec, r, tx), ret)]
 async fn handle_deferred_stream<C, T>(
     dec: C,
-    mut r: Incoming,
+    mut r: BufferedIncoming,
     path: Vec<usize>,
     tx: mpsc::Sender<Vec<T>>,
 ) -> std::io::Result<()>
 where
-    C: tokio_util::codec::Decoder<Item = T> + Deferred<Incoming>,
+    C: tokio_util::codec::Decoder<Item = T> + Deferred<BufferedIncoming>,
     std::io::Error: From<C::Error>,
 {
     let dec = ListDecoder::new(dec);
@@ -2094,7 +2094,7 @@ where
 impl<T> tokio_util::codec::Decoder for StreamDecoder<T>
 where
     T: Decode + Send + 'static,
-    T::ListDecoder: Deferred<Incoming>,
+    T::ListDecoder: Deferred<BufferedIncoming>,
     <T::Decoder as tokio_util::codec::Decoder>::Error: Send,
     std::io::Error: From<<T::Decoder as tokio_util::codec::Decoder>::Error>,
 {
@@ -2125,7 +2125,7 @@ where
 impl<T> Decode for Pin<Box<dyn Stream<Item = Vec<T>> + Send>>
 where
     T: Decode + Send + 'static,
-    T::ListDecoder: Deferred<Incoming> + Send,
+    T::ListDecoder: Deferred<BufferedIncoming> + Send,
     <T::Decoder as tokio_util::codec::Decoder>::Error: Send,
     std::io::Error: From<<T::Decoder as tokio_util::codec::Decoder>::Error>,
 {
@@ -2137,11 +2137,11 @@ where
 #[derive(Default)]
 pub struct StreamDecoderBytes {
     dec: CoreVecDecoderBytes,
-    deferred: Option<DeferredFn<Incoming>>,
+    deferred: Option<DeferredFn<BufferedIncoming>>,
 }
 
-impl Deferred<Incoming> for StreamDecoderBytes {
-    fn take_deferred(&mut self) -> Option<DeferredFn<Incoming>> {
+impl Deferred<BufferedIncoming> for StreamDecoderBytes {
+    fn take_deferred(&mut self) -> Option<DeferredFn<BufferedIncoming>> {
         self.deferred.take()
     }
 }
@@ -2201,11 +2201,11 @@ impl Decode for Pin<Box<dyn Stream<Item = Bytes> + Send>> {
 #[derive(Default)]
 pub struct StreamDecoderRead {
     dec: CoreVecDecoderBytes,
-    deferred: Option<DeferredFn<Incoming>>,
+    deferred: Option<DeferredFn<BufferedIncoming>>,
 }
 
-impl Deferred<Incoming> for StreamDecoderRead {
-    fn take_deferred(&mut self) -> Option<DeferredFn<Incoming>> {
+impl Deferred<BufferedIncoming> for StreamDecoderRead {
+    fn take_deferred(&mut self) -> Option<DeferredFn<BufferedIncoming>> {
         self.deferred.take()
     }
 }

--- a/crates/transport/src/value.rs
+++ b/crates/transport/src/value.rs
@@ -31,7 +31,8 @@ use wasm_tokio::{
     Leb128Encoder, Utf8Codec,
 };
 
-use crate::{Incoming, Index as _};
+use crate::Incoming;
+use crate::frame::Outgoing;
 
 /// Borrowed resource handle, represented as an opaque byte blob
 #[repr(transparent)]
@@ -356,30 +357,36 @@ where
     }
 }
 
-#[instrument(level = "trace", skip(w, deferred))]
-async fn handle_deferred<T, I>(w: T, deferred: I, mut path: Vec<usize>) -> std::io::Result<()>
-where
-    I: IntoIterator<Item = Option<DeferredFn<T>>>,
-    I::IntoIter: ExactSizeIterator,
-    T: crate::Index<T>,
-{
-    let mut futs = FuturesUnordered::default();
-    for (i, f) in zip(0.., deferred) {
-        if let Some(f) = f {
-            path.push(i);
-            let w = w.index(&path).map_err(std::io::Error::other)?;
-            path.pop();
-            futs.push(f(w, Vec::default()));
+macro_rules! impl_handle_deferred {
+    ($name:ident, $t:ty) => {
+        #[instrument(level = "trace", skip(w, deferred))]
+        async fn $name<I>(w: $t, deferred: I, mut path: Vec<usize>) -> std::io::Result<()>
+        where
+            I: IntoIterator<Item = Option<DeferredFn<$t>>>,
+            I::IntoIter: ExactSizeIterator,
+        {
+            let mut futs = FuturesUnordered::default();
+            for (i, f) in zip(0.., deferred) {
+                if let Some(f) = f {
+                    path.push(i);
+                    let w = w.index(&path).map_err(std::io::Error::other)?;
+                    path.pop();
+                    futs.push(f(w, Vec::default()));
+                }
+            }
+            while let Some(()) = futs.try_next().await? {}
+            Ok(())
         }
-    }
-    while let Some(()) = futs.try_next().await? {}
-    Ok(())
+    };
 }
 
+impl_handle_deferred!(handle_deferred_tx, Outgoing);
+impl_handle_deferred!(handle_deferred_rx, Incoming);
+
 /// Defines value encoding
-pub trait Encode<T>: Sized {
+pub trait Encode: Sized {
     /// Encoder used to encode the value
-    type Encoder: tokio_util::codec::Encoder<Self> + Deferred<T> + Default + Send;
+    type Encoder: tokio_util::codec::Encoder<Self> + Deferred<Outgoing> + Default + Send;
 
     /// Convenience function for encoding a value
     #[instrument(level = "trace", skip(self, enc))]
@@ -387,8 +394,10 @@ pub trait Encode<T>: Sized {
         self,
         enc: &mut Self::Encoder,
         dst: &mut BytesMut,
-    ) -> Result<Option<DeferredFn<T>>, <Self::Encoder as tokio_util::codec::Encoder<Self>>::Error>
-    {
+    ) -> Result<
+        Option<DeferredFn<Outgoing>>,
+        <Self::Encoder as tokio_util::codec::Encoder<Self>>::Error,
+    > {
         enc.encode(self, dst)?;
         Ok(enc.take_deferred())
     }
@@ -399,11 +408,13 @@ pub trait Encode<T>: Sized {
         items: I,
         enc: &mut Self::Encoder,
         dst: &mut BytesMut,
-    ) -> Result<Option<DeferredFn<T>>, <Self::Encoder as tokio_util::codec::Encoder<Self>>::Error>
+    ) -> Result<
+        Option<DeferredFn<Outgoing>>,
+        <Self::Encoder as tokio_util::codec::Encoder<Self>>::Error,
+    >
     where
         I: IntoIterator<Item = Self>,
         I::IntoIter: ExactSizeIterator,
-        T: crate::Index<T> + Send + Sync + 'static,
     {
         let items = items.into_iter();
         dst.reserve(items.len());
@@ -414,7 +425,7 @@ pub trait Encode<T>: Sized {
         }
         if deferred.iter().any(Option::is_some) {
             Ok(Some(Box::new(move |w, path| {
-                Box::pin(handle_deferred(w, deferred, path))
+                Box::pin(handle_deferred_tx(w, deferred, path))
             })))
         } else {
             Ok(None)
@@ -427,11 +438,13 @@ pub trait Encode<T>: Sized {
         items: I,
         enc: &mut Self::Encoder,
         dst: &mut BytesMut,
-    ) -> Result<Option<DeferredFn<T>>, <Self::Encoder as tokio_util::codec::Encoder<&'a Self>>::Error>
+    ) -> Result<
+        Option<DeferredFn<Outgoing>>,
+        <Self::Encoder as tokio_util::codec::Encoder<&'a Self>>::Error,
+    >
     where
         I: IntoIterator<Item = &'a Self>,
         I::IntoIter: ExactSizeIterator,
-        T: crate::Index<T> + Send + Sync + 'static,
         Self::Encoder: tokio_util::codec::Encoder<&'a Self>,
     {
         let items = items.into_iter();
@@ -443,7 +456,7 @@ pub trait Encode<T>: Sized {
         }
         if deferred.iter().any(Option::is_some) {
             Ok(Some(Box::new(move |w, path| {
-                Box::pin(handle_deferred(w, deferred, path))
+                Box::pin(handle_deferred_tx(w, deferred, path))
             })))
         } else {
             Ok(None)
@@ -456,10 +469,10 @@ pub trait Encode<T>: Sized {
         items: Vec<Self>,
         enc: &mut Self::Encoder,
         dst: &mut BytesMut,
-    ) -> Result<Option<DeferredFn<T>>, <Self::Encoder as tokio_util::codec::Encoder<Self>>::Error>
-    where
-        T: crate::Index<T> + Send + Sync + 'static,
-    {
+    ) -> Result<
+        Option<DeferredFn<Outgoing>>,
+        <Self::Encoder as tokio_util::codec::Encoder<Self>>::Error,
+    > {
         let n = u32::try_from(items.len())
             .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidInput, err))?;
         dst.reserve(5 + items.len());
@@ -473,9 +486,11 @@ pub trait Encode<T>: Sized {
         items: &'a [Self],
         enc: &mut Self::Encoder,
         dst: &mut BytesMut,
-    ) -> Result<Option<DeferredFn<T>>, <Self::Encoder as tokio_util::codec::Encoder<&'a Self>>::Error>
+    ) -> Result<
+        Option<DeferredFn<Outgoing>>,
+        <Self::Encoder as tokio_util::codec::Encoder<&'a Self>>::Error,
+    >
     where
-        T: crate::Index<T> + Send + Sync + 'static,
         Self::Encoder: tokio_util::codec::Encoder<&'a Self>,
     {
         let n = u32::try_from(items.len())
@@ -487,10 +502,10 @@ pub trait Encode<T>: Sized {
 }
 
 /// Defines value decoding
-pub trait Decode<T>: Sized {
+pub trait Decode: Sized {
     /// Decoder used to decode value
     type Decoder: tokio_util::codec::Decoder<Item = Self>
-        + Deferred<Incoming<T>>
+        + Deferred<Incoming>
         + Default
         + Send
         + 'static;
@@ -507,16 +522,16 @@ where
     }
 }
 
-impl<T, W> Encode<W> for Option<T>
+impl<T> Encode for Option<T>
 where
-    T: Encode<W>,
+    T: Encode,
 {
     type Encoder = OptionEncoder<T::Encoder>;
 }
 
-impl<'a, T, W> Encode<W> for &'a Option<T>
+impl<'a, T> Encode for &'a Option<T>
 where
-    T: Encode<W>,
+    T: Encode,
     T::Encoder: tokio_util::codec::Encoder<&'a T>,
 {
     type Encoder = OptionEncoder<T::Encoder>;
@@ -531,13 +546,12 @@ where
     }
 }
 
-impl<T, R> Decode<R> for Option<T>
+impl<T> Decode for Option<T>
 where
-    T: Decode<R>,
-    R: crate::Index<R> + Send + 'static,
+    T: Decode,
 {
     type Decoder = OptionDecoder<T::Decoder>;
-    type ListDecoder = ListDecoder<Self::Decoder, R>;
+    type ListDecoder = ListDecoder<Self::Decoder>;
 }
 
 impl<O, E, W> Deferred<W> for ResultEncoder<O, E>
@@ -560,21 +574,21 @@ where
     }
 }
 
-impl<O, E, W> Encode<W> for Result<O, E>
+impl<O, E> Encode for Result<O, E>
 where
-    O: Encode<W>,
-    E: Encode<W>,
+    O: Encode,
+    E: Encode,
     std::io::Error: From<<O::Encoder as tokio_util::codec::Encoder<O>>::Error>,
     std::io::Error: From<<E::Encoder as tokio_util::codec::Encoder<E>>::Error>,
 {
     type Encoder = ResultEncoder<O::Encoder, E::Encoder>;
 }
 
-impl<'a, O, E, W> Encode<W> for &'a Result<O, E>
+impl<'a, O, E> Encode for &'a Result<O, E>
 where
-    O: Encode<W>,
+    O: Encode,
     O::Encoder: tokio_util::codec::Encoder<&'a O>,
-    E: Encode<W>,
+    E: Encode,
     E::Encoder: tokio_util::codec::Encoder<&'a E>,
     std::io::Error: From<<O::Encoder as tokio_util::codec::Encoder<&'a O>>::Error>,
     std::io::Error: From<<E::Encoder as tokio_util::codec::Encoder<&'a E>>::Error>,
@@ -603,39 +617,32 @@ where
     }
 }
 
-impl<O, E, R> Decode<R> for Result<O, E>
+impl<O, E> Decode for Result<O, E>
 where
-    O: Decode<R>,
-    E: Decode<R>,
-    R: crate::Index<R> + Send + 'static,
+    O: Decode,
+    E: Decode,
     std::io::Error: From<<O::Decoder as tokio_util::codec::Decoder>::Error>,
     std::io::Error: From<<E::Decoder as tokio_util::codec::Decoder>::Error>,
 {
     type Decoder = ResultDecoder<O::Decoder, E::Decoder>;
-    type ListDecoder = ListDecoder<Self::Decoder, R>;
+    type ListDecoder = ListDecoder<Self::Decoder>;
 }
 
 /// Encoder for `list<T>`
-pub struct ListEncoder<W> {
-    deferred: Option<DeferredFn<W>>,
+#[derive(Default)]
+pub struct ListEncoder {
+    deferred: Option<DeferredFn<Outgoing>>,
 }
 
-impl<W> Default for ListEncoder<W> {
-    fn default() -> Self {
-        Self { deferred: None }
-    }
-}
-
-impl<W> Deferred<W> for ListEncoder<W> {
-    fn take_deferred(&mut self) -> Option<DeferredFn<W>> {
+impl Deferred<Outgoing> for ListEncoder {
+    fn take_deferred(&mut self) -> Option<DeferredFn<Outgoing>> {
         self.deferred.take()
     }
 }
 
-impl<T, W> tokio_util::codec::Encoder<Vec<T>> for ListEncoder<W>
+impl<T> tokio_util::codec::Encoder<Vec<T>> for ListEncoder
 where
-    T: Encode<W>,
-    W: crate::Index<W> + Send + Sync + 'static,
+    T: Encode,
 {
     type Error = <T::Encoder as tokio_util::codec::Encoder<T>>::Error;
 
@@ -646,11 +653,10 @@ where
     }
 }
 
-impl<'a, T, W> tokio_util::codec::Encoder<&'a Vec<T>> for ListEncoder<W>
+impl<'a, T> tokio_util::codec::Encoder<&'a Vec<T>> for ListEncoder
 where
-    T: Encode<W>,
+    T: Encode,
     T::Encoder: tokio_util::codec::Encoder<&'a T>,
-    W: crate::Index<W> + Send + Sync + 'static,
 {
     type Error = <T::Encoder as tokio_util::codec::Encoder<&'a T>>::Error;
 
@@ -661,11 +667,10 @@ where
     }
 }
 
-impl<'a, 'b, T, W> tokio_util::codec::Encoder<&'a &'b Vec<T>> for ListEncoder<W>
+impl<'a, 'b, T> tokio_util::codec::Encoder<&'a &'b Vec<T>> for ListEncoder
 where
-    T: Encode<W>,
+    T: Encode,
     T::Encoder: tokio_util::codec::Encoder<&'b T>,
-    W: crate::Index<W> + Send + Sync + 'static,
 {
     type Error = <T::Encoder as tokio_util::codec::Encoder<&'b T>>::Error;
 
@@ -676,11 +681,10 @@ where
     }
 }
 
-impl<'a, T, W> tokio_util::codec::Encoder<&'a [T]> for ListEncoder<W>
+impl<'a, T> tokio_util::codec::Encoder<&'a [T]> for ListEncoder
 where
-    T: Encode<W>,
+    T: Encode,
     T::Encoder: tokio_util::codec::Encoder<&'a T>,
-    W: crate::Index<W> + Send + Sync + 'static,
 {
     type Error = <T::Encoder as tokio_util::codec::Encoder<&'a T>>::Error;
 
@@ -691,11 +695,10 @@ where
     }
 }
 
-impl<'a, 'b, T, W> tokio_util::codec::Encoder<&'a &'b [T]> for ListEncoder<W>
+impl<'a, 'b, T> tokio_util::codec::Encoder<&'a &'b [T]> for ListEncoder
 where
-    T: Encode<W>,
+    T: Encode,
     T::Encoder: tokio_util::codec::Encoder<&'b T>,
-    W: crate::Index<W> + Send + Sync + 'static,
 {
     type Error = <T::Encoder as tokio_util::codec::Encoder<&'b T>>::Error;
 
@@ -706,44 +709,41 @@ where
     }
 }
 
-impl<T, W> Encode<W> for Vec<T>
+impl<T> Encode for Vec<T>
 where
-    T: Encode<W>,
-    W: crate::Index<W> + Send + Sync + 'static,
+    T: Encode,
 {
-    type Encoder = ListEncoder<W>;
+    type Encoder = ListEncoder;
 }
 
-impl<'a, T, W> Encode<W> for &'a Vec<T>
+impl<'a, T> Encode for &'a Vec<T>
 where
-    T: Encode<W>,
+    T: Encode,
     T::Encoder: tokio_util::codec::Encoder<&'a T>,
-    W: crate::Index<W> + Send + Sync + 'static,
 {
-    type Encoder = ListEncoder<W>;
+    type Encoder = ListEncoder;
 }
 
-impl<'a, T, W> Encode<W> for &'a [T]
+impl<'a, T> Encode for &'a [T]
 where
-    T: Encode<W>,
+    T: Encode,
     T::Encoder: tokio_util::codec::Encoder<&'a T>,
-    W: crate::Index<W> + Send + Sync + 'static,
 {
-    type Encoder = ListEncoder<W>;
+    type Encoder = ListEncoder;
 }
 
 /// Decoder for `list<T>`
-pub struct ListDecoder<T, R>
+pub struct ListDecoder<T>
 where
     T: tokio_util::codec::Decoder,
 {
     dec: T,
     ret: Vec<T::Item>,
     cap: usize,
-    deferred: Vec<Option<DeferredFn<Incoming<R>>>>,
+    deferred: Vec<Option<DeferredFn<Incoming>>>,
 }
 
-impl<T, R> ListDecoder<T, R>
+impl<T> ListDecoder<T>
 where
     T: tokio_util::codec::Decoder,
 {
@@ -758,7 +758,7 @@ where
     }
 }
 
-impl<T, R> Default for ListDecoder<T, R>
+impl<T> Default for ListDecoder<T>
 where
     T: tokio_util::codec::Decoder + Default,
 {
@@ -767,16 +767,15 @@ where
     }
 }
 
-impl<T, R> Deferred<Incoming<R>> for ListDecoder<T, R>
+impl<T> Deferred<Incoming> for ListDecoder<T>
 where
     T: tokio_util::codec::Decoder,
-    R: crate::Index<R> + Send + Sync + 'static,
 {
-    fn take_deferred(&mut self) -> Option<DeferredFn<Incoming<R>>> {
+    fn take_deferred(&mut self) -> Option<DeferredFn<Incoming>> {
         let deferred = mem::take(&mut self.deferred);
         if deferred.iter().any(Option::is_some) {
             Some(Box::new(|r, path| {
-                Box::pin(handle_deferred(r, deferred, path))
+                Box::pin(handle_deferred_rx(r, deferred, path))
             }))
         } else {
             None
@@ -784,9 +783,9 @@ where
     }
 }
 
-impl<T, R> tokio_util::codec::Decoder for ListDecoder<T, R>
+impl<T> tokio_util::codec::Decoder for ListDecoder<T>
 where
-    T: tokio_util::codec::Decoder + Deferred<Incoming<R>>,
+    T: tokio_util::codec::Decoder + Deferred<Incoming>,
 {
     type Item = Vec<T::Item>;
     type Error = T::Error;
@@ -819,19 +818,18 @@ where
     }
 }
 
-impl<T, R> Decode<R> for Vec<T>
+impl<T> Decode for Vec<T>
 where
-    T: Decode<R> + Send,
-    T::ListDecoder: Deferred<Incoming<R>> + Send,
-    R: crate::Index<R> + Send + 'static,
+    T: Decode + Send,
+    T::ListDecoder: Deferred<Incoming> + Send,
 {
     type Decoder = T::ListDecoder;
-    type ListDecoder = ListDecoder<Self::Decoder, R>;
+    type ListDecoder = ListDecoder<Self::Decoder>;
 }
 
 macro_rules! impl_copy_codec {
     ($t:ty, $c:tt) => {
-        impl<W> Encode<W> for $t {
+        impl Encode for $t {
             type Encoder = $c;
 
             #[instrument(level = "trace", skip(items))]
@@ -840,7 +838,7 @@ macro_rules! impl_copy_codec {
                 enc: &mut Self::Encoder,
                 dst: &mut BytesMut,
             ) -> Result<
-                Option<DeferredFn<W>>,
+                Option<DeferredFn<Outgoing>>,
                 <Self::Encoder as tokio_util::codec::Encoder<Self>>::Error,
             >
             where
@@ -861,7 +859,7 @@ macro_rules! impl_copy_codec {
                 enc: &mut Self::Encoder,
                 dst: &mut BytesMut,
             ) -> Result<
-                Option<DeferredFn<W>>,
+                Option<DeferredFn<Outgoing>>,
                 <Self::Encoder as tokio_util::codec::Encoder<&'a Self>>::Error,
             >
             where
@@ -877,7 +875,7 @@ macro_rules! impl_copy_codec {
             }
         }
 
-        impl<'b, W> Encode<W> for &'b $t {
+        impl<'b> Encode for &'b $t {
             type Encoder = $c;
 
             #[instrument(level = "trace", skip(items))]
@@ -886,7 +884,7 @@ macro_rules! impl_copy_codec {
                 enc: &mut Self::Encoder,
                 dst: &mut BytesMut,
             ) -> Result<
-                Option<DeferredFn<W>>,
+                Option<DeferredFn<Outgoing>>,
                 <Self::Encoder as tokio_util::codec::Encoder<Self>>::Error,
             >
             where
@@ -907,7 +905,7 @@ macro_rules! impl_copy_codec {
                 enc: &mut Self::Encoder,
                 dst: &mut BytesMut,
             ) -> Result<
-                Option<DeferredFn<W>>,
+                Option<DeferredFn<Outgoing>>,
                 <Self::Encoder as tokio_util::codec::Encoder<&'a Self>>::Error,
             >
             where
@@ -924,7 +922,7 @@ macro_rules! impl_copy_codec {
             }
         }
 
-        impl<R> Decode<R> for $t {
+        impl Decode for $t {
             type Decoder = $c;
             type ListDecoder = CoreVecDecoder<Self::Decoder>;
         }
@@ -1007,7 +1005,7 @@ impl_copy_codec!(f32, CanonicalNanF32Codec);
 impl_copy_codec!(f64, CanonicalNanF64Codec);
 impl_copy_codec!(char, Utf8Codec);
 
-impl<T> Encode<T> for u8 {
+impl Encode for u8 {
     type Encoder = U8Codec;
 
     #[instrument(level = "trace", skip(items))]
@@ -1015,7 +1013,10 @@ impl<T> Encode<T> for u8 {
         items: I,
         enc: &mut Self::Encoder,
         dst: &mut BytesMut,
-    ) -> Result<Option<DeferredFn<T>>, <Self::Encoder as tokio_util::codec::Encoder<Self>>::Error>
+    ) -> Result<
+        Option<DeferredFn<Outgoing>>,
+        <Self::Encoder as tokio_util::codec::Encoder<Self>>::Error,
+    >
     where
         I: IntoIterator<Item = Self>,
         I::IntoIter: ExactSizeIterator,
@@ -1031,7 +1032,10 @@ impl<T> Encode<T> for u8 {
         items: I,
         enc: &mut Self::Encoder,
         dst: &mut BytesMut,
-    ) -> Result<Option<DeferredFn<T>>, <Self::Encoder as tokio_util::codec::Encoder<&'a Self>>::Error>
+    ) -> Result<
+        Option<DeferredFn<Outgoing>>,
+        <Self::Encoder as tokio_util::codec::Encoder<&'a Self>>::Error,
+    >
     where
         I: IntoIterator<Item = &'a Self>,
         I::IntoIter: ExactSizeIterator,
@@ -1047,8 +1051,10 @@ impl<T> Encode<T> for u8 {
         items: Vec<Self>,
         enc: &mut Self::Encoder,
         dst: &mut BytesMut,
-    ) -> Result<Option<DeferredFn<T>>, <Self::Encoder as tokio_util::codec::Encoder<Self>>::Error>
-    {
+    ) -> Result<
+        Option<DeferredFn<Outgoing>>,
+        <Self::Encoder as tokio_util::codec::Encoder<Self>>::Error,
+    > {
         CoreVecEncoderBytes.encode(items, dst)?;
         Ok(None)
     }
@@ -1058,7 +1064,10 @@ impl<T> Encode<T> for u8 {
         items: &'a [Self],
         enc: &mut Self::Encoder,
         dst: &mut BytesMut,
-    ) -> Result<Option<DeferredFn<T>>, <Self::Encoder as tokio_util::codec::Encoder<&'a Self>>::Error>
+    ) -> Result<
+        Option<DeferredFn<Outgoing>>,
+        <Self::Encoder as tokio_util::codec::Encoder<&'a Self>>::Error,
+    >
     where
         Self::Encoder: tokio_util::codec::Encoder<&'a Self>,
     {
@@ -1067,7 +1076,7 @@ impl<T> Encode<T> for u8 {
     }
 }
 
-impl<'b, T> Encode<T> for &'b u8 {
+impl<'b> Encode for &'b u8 {
     type Encoder = U8Codec;
 
     #[instrument(level = "trace", skip(items))]
@@ -1075,7 +1084,10 @@ impl<'b, T> Encode<T> for &'b u8 {
         items: I,
         enc: &mut Self::Encoder,
         dst: &mut BytesMut,
-    ) -> Result<Option<DeferredFn<T>>, <Self::Encoder as tokio_util::codec::Encoder<Self>>::Error>
+    ) -> Result<
+        Option<DeferredFn<Outgoing>>,
+        <Self::Encoder as tokio_util::codec::Encoder<Self>>::Error,
+    >
     where
         I: IntoIterator<Item = Self>,
         I::IntoIter: ExactSizeIterator,
@@ -1091,7 +1103,10 @@ impl<'b, T> Encode<T> for &'b u8 {
         items: I,
         enc: &mut Self::Encoder,
         dst: &mut BytesMut,
-    ) -> Result<Option<DeferredFn<T>>, <Self::Encoder as tokio_util::codec::Encoder<&'a Self>>::Error>
+    ) -> Result<
+        Option<DeferredFn<Outgoing>>,
+        <Self::Encoder as tokio_util::codec::Encoder<&'a Self>>::Error,
+    >
     where
         I: IntoIterator<Item = &'a Self>,
         I::IntoIter: ExactSizeIterator,
@@ -1122,41 +1137,41 @@ impl tokio_util::codec::Decoder for ListDecoderU8 {
     }
 }
 
-impl<R> Decode<R> for u8 {
+impl Decode for u8 {
     type Decoder = U8Codec;
     type ListDecoder = ListDecoderU8;
 }
 
-impl<W> Encode<W> for &str {
+impl Encode for &str {
     type Encoder = CoreNameEncoder;
 }
 
-impl<W> Encode<W> for &&str {
+impl Encode for &&str {
     type Encoder = CoreNameEncoder;
 }
 
-impl<W> Encode<W> for String {
+impl Encode for String {
     type Encoder = CoreNameEncoder;
 }
 
-impl<W> Encode<W> for &String {
+impl Encode for &String {
     type Encoder = CoreNameEncoder;
 }
 
-impl<R> Decode<R> for String {
+impl Decode for String {
     type Decoder = CoreNameDecoder;
     type ListDecoder = CoreVecDecoder<Self::Decoder>;
 }
 
-impl<W> Encode<W> for Bytes {
+impl Encode for Bytes {
     type Encoder = CoreVecEncoderBytes;
 }
 
-impl<W> Encode<W> for &Bytes {
+impl Encode for &Bytes {
     type Encoder = CoreVecEncoderBytes;
 }
 
-impl<R> Decode<R> for Bytes {
+impl Decode for Bytes {
     type Decoder = CoreVecDecoderBytes;
     type ListDecoder = CoreVecDecoder<Self::Decoder>;
 }
@@ -1184,11 +1199,11 @@ impl<T: ?Sized> tokio_util::codec::Encoder<&ResourceOwn<T>> for ResourceEncoder 
     }
 }
 
-impl<T: ?Sized, W> Encode<W> for ResourceOwn<T> {
+impl<T: ?Sized> Encode for ResourceOwn<T> {
     type Encoder = ResourceEncoder;
 }
 
-impl<T: ?Sized, W> Encode<W> for &ResourceOwn<T> {
+impl<T: ?Sized> Encode for &ResourceOwn<T> {
     type Encoder = ResourceEncoder;
 }
 
@@ -1210,11 +1225,11 @@ impl<T: ?Sized> tokio_util::codec::Encoder<&ResourceBorrow<T>> for ResourceEncod
     }
 }
 
-impl<T: ?Sized, W> Encode<W> for ResourceBorrow<T> {
+impl<T: ?Sized> Encode for ResourceBorrow<T> {
     type Encoder = ResourceEncoder;
 }
 
-impl<T: ?Sized, W> Encode<W> for &ResourceBorrow<T> {
+impl<T: ?Sized> Encode for &ResourceBorrow<T> {
     type Encoder = ResourceEncoder;
 }
 
@@ -1235,19 +1250,19 @@ impl<T: ?Sized> Default for ResourceBorrowDecoder<T> {
     }
 }
 
-impl<R, T: ?Sized> Deferred<Incoming<R>> for ResourceBorrowDecoder<T> {
-    fn take_deferred(&mut self) -> Option<DeferredFn<Incoming<R>>> {
+impl<T: ?Sized> Deferred<Incoming> for ResourceBorrowDecoder<T> {
+    fn take_deferred(&mut self) -> Option<DeferredFn<Incoming>> {
         None
     }
 }
 
-impl<R, T: ?Sized> Deferred<Incoming<R>> for CoreVecDecoder<ResourceBorrowDecoder<T>> {
-    fn take_deferred(&mut self) -> Option<DeferredFn<Incoming<R>>> {
+impl<T: ?Sized> Deferred<Incoming> for CoreVecDecoder<ResourceBorrowDecoder<T>> {
+    fn take_deferred(&mut self) -> Option<DeferredFn<Incoming>> {
         None
     }
 }
 
-impl<R, T: ?Sized + Send + 'static> Decode<R> for ResourceBorrow<T> {
+impl<T: ?Sized + Send + 'static> Decode for ResourceBorrow<T> {
     type Decoder = ResourceBorrowDecoder<T>;
     type ListDecoder = CoreVecDecoder<Self::Decoder>;
 }
@@ -1280,19 +1295,19 @@ impl<T: ?Sized> Default for ResourceOwnDecoder<T> {
     }
 }
 
-impl<R, T: ?Sized> Deferred<Incoming<R>> for ResourceOwnDecoder<T> {
-    fn take_deferred(&mut self) -> Option<DeferredFn<Incoming<R>>> {
+impl<T: ?Sized> Deferred<Incoming> for ResourceOwnDecoder<T> {
+    fn take_deferred(&mut self) -> Option<DeferredFn<Incoming>> {
         None
     }
 }
 
-impl<R, T: ?Sized> Deferred<Incoming<R>> for CoreVecDecoder<ResourceOwnDecoder<T>> {
-    fn take_deferred(&mut self) -> Option<DeferredFn<Incoming<R>>> {
+impl<T: ?Sized> Deferred<Incoming> for CoreVecDecoder<ResourceOwnDecoder<T>> {
+    fn take_deferred(&mut self) -> Option<DeferredFn<Incoming>> {
         None
     }
 }
 
-impl<R, T: ?Sized + Send + 'static> Decode<R> for ResourceOwn<T> {
+impl<T: ?Sized + Send + 'static> Decode for ResourceOwn<T> {
     type Decoder = ResourceOwnDecoder<T>;
     type ListDecoder = CoreVecDecoder<Self::Decoder>;
 }
@@ -1342,112 +1357,105 @@ impl tokio_util::codec::Decoder for UnitCodec {
 }
 
 /// Marker trait for [Encode] tuple types
-pub trait TupleEncode<W>: Encode<W> {}
+pub trait TupleEncode: Encode {}
 
 /// Marker trait for [Decode] tuple types
-pub trait TupleDecode<R>: Decode<R> {}
+pub trait TupleDecode: Decode {}
 
-impl<W> Encode<W> for () {
+impl Encode for () {
     type Encoder = UnitCodec;
 }
 
-impl<W> TupleEncode<W> for () {}
+impl TupleEncode for () {}
 
-impl<R> Decode<R> for () {
+impl Decode for () {
     type Decoder = UnitCodec;
     type ListDecoder = CoreVecDecoder<Self::Decoder>;
 }
 
-impl<R> TupleDecode<R> for () {}
+impl TupleDecode for () {}
 
 macro_rules! impl_tuple_codec {
     ($($vn:ident),+; $($vt:ident),+; $($cn:ident),+; $($ct:ident),+) => {
-        impl<W, $($ct),+> Deferred<W> for TupleEncoder::<($($ct),+,)>
+        impl<$($ct),+> Deferred<Outgoing> for TupleEncoder::<($($ct),+,)>
         where
-            W: crate::Index<W> + Send + Sync + 'static,
-            $($ct: Deferred<W> + Default + 'static),+
+            $($ct: Deferred<Outgoing> + Default + 'static),+
         {
-            fn take_deferred(&mut self) -> Option<DeferredFn<W>> {
+            fn take_deferred(&mut self) -> Option<DeferredFn<Outgoing>> {
                 let Self(($(mut $cn),+,)) = mem::take(self);
                 let deferred = [ $($cn.take_deferred()),+ ];
                 if deferred.iter().any(Option::is_some) {
-                    Some(Box::new(|r, path| Box::pin(handle_deferred(r, deferred, path))))
+                    Some(Box::new(|r, path| Box::pin(handle_deferred_tx(r, deferred, path))))
                 } else {
                     None
                 }
             }
         }
 
-        impl<W, E, $($vt),+> Encode<W> for ($($vt),+,)
+        impl<E, $($vt),+> Encode for ($($vt),+,)
         where
-            W: crate::Index<W> + Send + Sync + 'static,
             E: From<std::io::Error>,
             $(
-                $vt: Encode<W>,
+                $vt: Encode,
                 $vt::Encoder: tokio_util::codec::Encoder<$vt, Error = E> + 'static,
             )+
         {
             type Encoder = TupleEncoder::<($($vt::Encoder),+,)>;
         }
 
-        impl<W, E, $($vt),+> TupleEncode<W> for ($($vt),+,)
+        impl<E, $($vt),+> TupleEncode for ($($vt),+,)
         where
-            W: crate::Index<W> + Send + Sync + 'static,
             E: From<std::io::Error>,
             $(
-                $vt: Encode<W>,
+                $vt: Encode,
                 $vt::Encoder: tokio_util::codec::Encoder<$vt, Error = E> + 'static,
             )+
         {
         }
 
-        impl<'a, W, E, $($vt),+> Encode<W> for &'a ($($vt),+,)
+        impl<'a, E, $($vt),+> Encode for &'a ($($vt),+,)
         where
-            W: crate::Index<W> + Send + Sync + 'static,
             E: From<std::io::Error>,
             $(
-                $vt: Encode<W>,
+                $vt: Encode,
                 $vt::Encoder: tokio_util::codec::Encoder<&'a $vt, Error = E> + 'static,
             )+
         {
             type Encoder = TupleEncoder::<($($vt::Encoder),+,)>;
         }
 
-        impl<R, $($vt),+> Deferred<Incoming<R>> for TupleDecoder::<($($vt::Decoder),+,), ($(Option<$vt>),+,)>
+        impl<$($vt),+> Deferred<Incoming> for TupleDecoder::<($($vt::Decoder),+,), ($(Option<$vt>),+,)>
         where
-            R: crate::Index<R> + Send + Sync + 'static,
-            $($vt: Decode<R>),+
+            $($vt: Decode),+
         {
-            fn take_deferred(&mut self) -> Option<DeferredFn<Incoming<R>>> {
+            fn take_deferred(&mut self) -> Option<DeferredFn<Incoming>> {
                 let ($(mut $cn),+,) = mem::take(self).into_inner();
                 let deferred = [ $($cn.take_deferred()),+ ];
                 if deferred.iter().any(Option::is_some) {
-                    Some(Box::new(|r, path| Box::pin(handle_deferred(r, deferred, path))))
+                    Some(Box::new(|r, path| Box::pin(handle_deferred_rx(r, deferred, path))))
                 } else {
                     None
                 }
             }
         }
 
-        impl<R, E, $($vt),+> Decode<R> for ($($vt),+,)
+        impl<E, $($vt),+> Decode for ($($vt),+,)
         where
-            R: crate::Index<R> + Send + Sync + 'static,
             E: From<std::io::Error>,
             $(
-                $vt: Decode<R> + Send + 'static,
+                $vt: Decode + Send + 'static,
                 $vt::Decoder: tokio_util::codec::Decoder<Error = E> + Send + 'static,
             )+
         {
             type Decoder = TupleDecoder::<($($vt::Decoder),+,), ($(Option<$vt>),+,)>;
-            type ListDecoder = ListDecoder<Self::Decoder, R>;
+            type ListDecoder = ListDecoder<Self::Decoder>;
         }
 
-        impl<R, E, $($vt),+> TupleDecode<R> for ($($vt),+,)
+        impl<E, $($vt),+> TupleDecode for ($($vt),+,)
         where
-            R: crate::Index<R> + Send + Sync + 'static,
             E: From<std::io::Error>,
             $(
-                $vt: Decode<R> + Send + 'static,
+                $vt: Decode + Send + 'static,
                 $vt::Decoder: tokio_util::codec::Decoder<Error = E> + Send + 'static,
             )+
         {
@@ -1568,26 +1576,20 @@ impl_tuple_codec!(
 );
 
 /// Encoder for `future<T>`
-pub struct FutureEncoder<W> {
-    deferred: Option<DeferredFn<W>>,
+#[derive(Default)]
+pub struct FutureEncoder {
+    deferred: Option<DeferredFn<Outgoing>>,
 }
 
-impl<W> Default for FutureEncoder<W> {
-    fn default() -> Self {
-        Self { deferred: None }
-    }
-}
-
-impl<W> Deferred<W> for FutureEncoder<W> {
-    fn take_deferred(&mut self) -> Option<DeferredFn<W>> {
+impl Deferred<Outgoing> for FutureEncoder {
+    fn take_deferred(&mut self) -> Option<DeferredFn<Outgoing>> {
         self.deferred.take()
     }
 }
 
-impl<T, W, Fut> tokio_util::codec::Encoder<Fut> for FutureEncoder<W>
+impl<T, Fut> tokio_util::codec::Encoder<Fut> for FutureEncoder
 where
-    T: Encode<W>,
-    W: AsyncWrite + crate::Index<W> + Send + Sync + Unpin + 'static,
+    T: Encode,
     Fut: Future<Output = T> + Send + 'static,
     std::io::Error: From<<T::Encoder as tokio_util::codec::Encoder<T>>::Error>,
 {
@@ -1622,28 +1624,27 @@ where
     }
 }
 
-impl<T, W> Encode<W> for Pin<Box<dyn Future<Output = T> + Send>>
+impl<T> Encode for Pin<Box<dyn Future<Output = T> + Send>>
 where
-    T: Encode<W> + 'static,
-    W: AsyncWrite + crate::Index<W> + Send + Sync + Unpin + 'static,
+    T: Encode + 'static,
     std::io::Error: From<<T::Encoder as tokio_util::codec::Encoder<T>>::Error>,
 {
-    type Encoder = FutureEncoder<W>;
+    type Encoder = FutureEncoder;
 }
 
 /// Decoder for `future<T>`
-pub struct FutureDecoder<T, R>
+pub struct FutureDecoder<T>
 where
-    T: Decode<R>,
+    T: Decode,
 {
     dec: OptionDecoder<T::Decoder>,
-    deferred: Option<DeferredFn<Incoming<R>>>,
+    deferred: Option<DeferredFn<Incoming>>,
     _ty: PhantomData<T>,
 }
 
-impl<T, R> Default for FutureDecoder<T, R>
+impl<T> Default for FutureDecoder<T>
 where
-    T: Decode<R>,
+    T: Decode,
 {
     fn default() -> Self {
         Self {
@@ -1654,19 +1655,18 @@ where
     }
 }
 
-impl<T, R> Deferred<Incoming<R>> for FutureDecoder<T, R>
+impl<T> Deferred<Incoming> for FutureDecoder<T>
 where
-    T: Decode<R>,
+    T: Decode,
 {
-    fn take_deferred(&mut self) -> Option<DeferredFn<Incoming<R>>> {
+    fn take_deferred(&mut self) -> Option<DeferredFn<Incoming>> {
         self.deferred.take()
     }
 }
 
-impl<T, R> tokio_util::codec::Decoder for FutureDecoder<T, R>
+impl<T> tokio_util::codec::Decoder for FutureDecoder<T>
 where
-    T: Decode<R> + Send + 'static,
-    R: AsyncRead + crate::Index<R> + Send + Sync + Unpin + 'static,
+    T: Decode + Send + 'static,
     std::io::Error: From<<T::Decoder as tokio_util::codec::Decoder>::Error>,
 {
     type Item = Pin<Box<dyn Future<Output = T> + Send>>;
@@ -1727,37 +1727,30 @@ where
     }
 }
 
-impl<T, R> Decode<R> for Pin<Box<dyn Future<Output = T> + Send>>
+impl<T> Decode for Pin<Box<dyn Future<Output = T> + Send>>
 where
-    T: Decode<R> + Send + 'static,
-    R: AsyncRead + crate::Index<R> + Send + Sync + Unpin + 'static,
+    T: Decode + Send + 'static,
     std::io::Error: From<<T::Decoder as tokio_util::codec::Decoder>::Error>,
 {
-    type Decoder = FutureDecoder<T, R>;
-    type ListDecoder = ListDecoder<Self::Decoder, R>;
+    type Decoder = FutureDecoder<T>;
+    type ListDecoder = ListDecoder<Self::Decoder>;
 }
 
 /// Encoder for `stream<T>`
-pub struct StreamEncoder<W> {
-    deferred: Option<DeferredFn<W>>,
+#[derive(Default)]
+pub struct StreamEncoder {
+    deferred: Option<DeferredFn<Outgoing>>,
 }
 
-impl<W> Default for StreamEncoder<W> {
-    fn default() -> Self {
-        Self { deferred: None }
-    }
-}
-
-impl<W> Deferred<W> for StreamEncoder<W> {
-    fn take_deferred(&mut self) -> Option<DeferredFn<W>> {
+impl Deferred<Outgoing> for StreamEncoder {
+    fn take_deferred(&mut self) -> Option<DeferredFn<Outgoing>> {
         self.deferred.take()
     }
 }
 
-impl<T, W, S> tokio_util::codec::Encoder<S> for StreamEncoder<W>
+impl<T, S> tokio_util::codec::Encoder<S> for StreamEncoder
 where
-    T: Encode<W> + Send + 'static,
-    W: AsyncWrite + crate::Index<W> + Send + Sync + Unpin + 'static,
+    T: Encode + Send + 'static,
     S: Stream<Item = Vec<T>> + Send + Unpin + 'static,
     std::io::Error: From<<T::Encoder as tokio_util::codec::Encoder<T>>::Error>,
 {
@@ -1836,35 +1829,28 @@ where
     }
 }
 
-impl<T, W> Encode<W> for Pin<Box<dyn Stream<Item = Vec<T>> + Send>>
+impl<T> Encode for Pin<Box<dyn Stream<Item = Vec<T>> + Send>>
 where
-    T: Encode<W> + Send + 'static,
-    W: AsyncWrite + crate::Index<W> + Send + Sync + Unpin + 'static,
+    T: Encode + Send + 'static,
     std::io::Error: From<<T::Encoder as tokio_util::codec::Encoder<T>>::Error>,
 {
-    type Encoder = StreamEncoder<W>;
+    type Encoder = StreamEncoder;
 }
 
 /// Encoder for `stream<list<u8>>`
-pub struct StreamEncoderBytes<W> {
-    deferred: Option<DeferredFn<W>>,
+#[derive(Default)]
+pub struct StreamEncoderBytes {
+    deferred: Option<DeferredFn<Outgoing>>,
 }
 
-impl<W> Default for StreamEncoderBytes<W> {
-    fn default() -> Self {
-        Self { deferred: None }
-    }
-}
-
-impl<W> Deferred<W> for StreamEncoderBytes<W> {
-    fn take_deferred(&mut self) -> Option<DeferredFn<W>> {
+impl Deferred<Outgoing> for StreamEncoderBytes {
+    fn take_deferred(&mut self) -> Option<DeferredFn<Outgoing>> {
         self.deferred.take()
     }
 }
 
-impl<W, S> tokio_util::codec::Encoder<S> for StreamEncoderBytes<W>
+impl<S> tokio_util::codec::Encoder<S> for StreamEncoderBytes
 where
-    W: AsyncWrite + crate::Index<W> + Send + Sync + Unpin + 'static,
     S: Stream<Item = Bytes> + Send + Unpin + 'static,
 {
     type Error = std::io::Error;
@@ -1908,33 +1894,24 @@ where
     }
 }
 
-impl<W> Encode<W> for Pin<Box<dyn Stream<Item = Bytes> + Send>>
-where
-    W: AsyncWrite + crate::Index<W> + Send + Sync + Unpin + 'static,
-{
-    type Encoder = StreamEncoderBytes<W>;
+impl Encode for Pin<Box<dyn Stream<Item = Bytes> + Send>> {
+    type Encoder = StreamEncoderBytes;
 }
 
 /// Encoder for `stream<list<u8>>` with [`AsyncRead`] support
-pub struct StreamEncoderRead<W> {
-    deferred: Option<DeferredFn<W>>,
+#[derive(Default)]
+pub struct StreamEncoderRead {
+    deferred: Option<DeferredFn<Outgoing>>,
 }
 
-impl<W> Default for StreamEncoderRead<W> {
-    fn default() -> Self {
-        Self { deferred: None }
-    }
-}
-
-impl<W> Deferred<W> for StreamEncoderRead<W> {
-    fn take_deferred(&mut self) -> Option<DeferredFn<W>> {
+impl Deferred<Outgoing> for StreamEncoderRead {
+    fn take_deferred(&mut self) -> Option<DeferredFn<Outgoing>> {
         self.deferred.take()
     }
 }
 
-impl<W, S> tokio_util::codec::Encoder<S> for StreamEncoderRead<W>
+impl<S> tokio_util::codec::Encoder<S> for StreamEncoderRead
 where
-    W: AsyncWrite + crate::Index<W> + Send + Sync + Unpin + 'static,
     S: AsyncRead + Send + Unpin + 'static,
 {
     type Error = std::io::Error;
@@ -1981,81 +1958,59 @@ where
     }
 }
 
-impl<W> Encode<W> for Pin<Box<dyn AsyncRead + Send>>
-where
-    W: AsyncWrite + crate::Index<W> + Send + Sync + Unpin + 'static,
-{
-    type Encoder = StreamEncoderRead<W>;
+impl Encode for Pin<Box<dyn AsyncRead + Send>> {
+    type Encoder = StreamEncoderRead;
 }
 
-impl<T, W> Encode<W> for std::io::Cursor<T>
+impl<T> Encode for std::io::Cursor<T>
 where
     T: AsRef<[u8]> + Send + Unpin + 'static,
-    W: AsyncWrite + crate::Index<W> + Send + Sync + Unpin + 'static,
 {
-    type Encoder = StreamEncoderRead<W>;
+    type Encoder = StreamEncoderRead;
 }
 
-impl<W> Encode<W> for tokio::io::Empty
-where
-    W: AsyncWrite + crate::Index<W> + Send + Sync + Unpin + 'static,
-{
-    type Encoder = StreamEncoderRead<W>;
+impl Encode for tokio::io::Empty {
+    type Encoder = StreamEncoderRead;
 }
 
 #[cfg(feature = "io-std")]
-impl<W> Encode<W> for tokio::io::Stdin
-where
-    W: AsyncWrite + crate::Index<W> + Send + Sync + Unpin + 'static,
-{
-    type Encoder = StreamEncoderRead<W>;
+impl Encode for tokio::io::Stdin {
+    type Encoder = StreamEncoderRead;
 }
 
 #[cfg(feature = "fs")]
-impl<W> Encode<W> for tokio::fs::File
-where
-    W: AsyncWrite + crate::Index<W> + Send + Sync + Unpin + 'static,
-{
-    type Encoder = StreamEncoderRead<W>;
+impl Encode for tokio::fs::File {
+    type Encoder = StreamEncoderRead;
 }
 
 #[cfg(feature = "net")]
-impl<W> Encode<W> for tokio::net::TcpStream
-where
-    W: AsyncWrite + crate::Index<W> + Send + Sync + Unpin + 'static,
-{
-    type Encoder = StreamEncoderRead<W>;
+impl Encode for tokio::net::TcpStream {
+    type Encoder = StreamEncoderRead;
 }
 
 #[cfg(all(unix, feature = "net"))]
-impl<W> Encode<W> for tokio::net::UnixStream
-where
-    W: AsyncWrite + crate::Index<W> + Send + Sync + Unpin + 'static,
-{
-    type Encoder = StreamEncoderRead<W>;
+impl Encode for tokio::net::UnixStream {
+    type Encoder = StreamEncoderRead;
 }
 
 #[cfg(all(unix, feature = "net"))]
-impl<W> Encode<W> for tokio::net::unix::pipe::Receiver
-where
-    W: AsyncWrite + crate::Index<W> + Send + Sync + Unpin + 'static,
-{
-    type Encoder = StreamEncoderRead<W>;
+impl Encode for tokio::net::unix::pipe::Receiver {
+    type Encoder = StreamEncoderRead;
 }
 
 /// Decoder for `stream<T>`
-pub struct StreamDecoder<T, R>
+pub struct StreamDecoder<T>
 where
-    T: Decode<R>,
+    T: Decode,
 {
     dec: T::ListDecoder,
-    deferred: Option<DeferredFn<Incoming<R>>>,
+    deferred: Option<DeferredFn<Incoming>>,
     _ty: PhantomData<T>,
 }
 
-impl<T, R> Default for StreamDecoder<T, R>
+impl<T> Default for StreamDecoder<T>
 where
-    T: Decode<R>,
+    T: Decode,
 {
     fn default() -> Self {
         Self {
@@ -2066,25 +2021,24 @@ where
     }
 }
 
-impl<T, R> Deferred<Incoming<R>> for StreamDecoder<T, R>
+impl<T> Deferred<Incoming> for StreamDecoder<T>
 where
-    T: Decode<R>,
+    T: Decode,
 {
-    fn take_deferred(&mut self) -> Option<DeferredFn<Incoming<R>>> {
+    fn take_deferred(&mut self) -> Option<DeferredFn<Incoming>> {
         self.deferred.take()
     }
 }
 
 #[instrument(level = "trace", skip(dec, r, tx), ret)]
-async fn handle_deferred_stream<C, T, R>(
+async fn handle_deferred_stream<C, T>(
     dec: C,
-    mut r: Incoming<R>,
+    mut r: Incoming,
     path: Vec<usize>,
     tx: mpsc::Sender<Vec<T>>,
 ) -> std::io::Result<()>
 where
-    C: tokio_util::codec::Decoder<Item = T> + Deferred<Incoming<R>>,
-    R: AsyncRead + crate::Index<R> + Send + Unpin + 'static,
+    C: tokio_util::codec::Decoder<Item = T> + Deferred<Incoming>,
     std::io::Error: From<C::Error>,
 {
     let dec = ListDecoder::new(dec);
@@ -2137,16 +2091,15 @@ where
     }
 }
 
-impl<T, R> tokio_util::codec::Decoder for StreamDecoder<T, R>
+impl<T> tokio_util::codec::Decoder for StreamDecoder<T>
 where
-    T: Decode<R> + Send + 'static,
-    T::ListDecoder: Deferred<Incoming<R>>,
-    R: AsyncRead + crate::Index<R> + Send + Sync + Unpin + 'static,
+    T: Decode + Send + 'static,
+    T::ListDecoder: Deferred<Incoming>,
     <T::Decoder as tokio_util::codec::Decoder>::Error: Send,
     std::io::Error: From<<T::Decoder as tokio_util::codec::Decoder>::Error>,
 {
     type Item = Pin<Box<dyn Stream<Item = Vec<T>> + Send>>;
-    type Error = <<T as Decode<R>>::ListDecoder as tokio_util::codec::Decoder>::Error;
+    type Error = <<T as Decode>::ListDecoder as tokio_util::codec::Decoder>::Error;
 
     #[instrument(level = "trace", skip(self), fields(ty = "stream"))]
     fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
@@ -2169,43 +2122,31 @@ where
     }
 }
 
-impl<T, R> Decode<R> for Pin<Box<dyn Stream<Item = Vec<T>> + Send>>
+impl<T> Decode for Pin<Box<dyn Stream<Item = Vec<T>> + Send>>
 where
-    T: Decode<R> + Send + 'static,
-    T::ListDecoder: Deferred<Incoming<R>> + Send,
-    R: AsyncRead + crate::Index<R> + Send + Sync + Unpin + 'static,
+    T: Decode + Send + 'static,
+    T::ListDecoder: Deferred<Incoming> + Send,
     <T::Decoder as tokio_util::codec::Decoder>::Error: Send,
     std::io::Error: From<<T::Decoder as tokio_util::codec::Decoder>::Error>,
 {
-    type Decoder = StreamDecoder<T, R>;
-    type ListDecoder = ListDecoder<Self::Decoder, R>;
+    type Decoder = StreamDecoder<T>;
+    type ListDecoder = ListDecoder<Self::Decoder>;
 }
 
 /// Decoder for `stream<list<u8>>`
-pub struct StreamDecoderBytes<R> {
+#[derive(Default)]
+pub struct StreamDecoderBytes {
     dec: CoreVecDecoderBytes,
-    deferred: Option<DeferredFn<Incoming<R>>>,
+    deferred: Option<DeferredFn<Incoming>>,
 }
 
-impl<R> Default for StreamDecoderBytes<R> {
-    fn default() -> Self {
-        Self {
-            dec: CoreVecDecoderBytes::default(),
-            deferred: None,
-        }
-    }
-}
-
-impl<R> Deferred<Incoming<R>> for StreamDecoderBytes<R> {
-    fn take_deferred(&mut self) -> Option<DeferredFn<Incoming<R>>> {
+impl Deferred<Incoming> for StreamDecoderBytes {
+    fn take_deferred(&mut self) -> Option<DeferredFn<Incoming>> {
         self.deferred.take()
     }
 }
 
-impl<R> tokio_util::codec::Decoder for StreamDecoderBytes<R>
-where
-    R: AsyncRead + crate::Index<R> + Send + Sync + Unpin + 'static,
-{
+impl tokio_util::codec::Decoder for StreamDecoderBytes {
     type Item = Pin<Box<dyn Stream<Item = Bytes> + Send>>;
     type Error = std::io::Error;
 
@@ -2251,39 +2192,25 @@ where
     }
 }
 
-impl<R> Decode<R> for Pin<Box<dyn Stream<Item = Bytes> + Send>>
-where
-    R: AsyncRead + crate::Index<R> + Send + Sync + Unpin + 'static,
-{
-    type Decoder = StreamDecoderBytes<R>;
-    type ListDecoder = ListDecoder<Self::Decoder, R>;
+impl Decode for Pin<Box<dyn Stream<Item = Bytes> + Send>> {
+    type Decoder = StreamDecoderBytes;
+    type ListDecoder = ListDecoder<Self::Decoder>;
 }
 
 /// Decoder for `stream<list<u8>>` with [`AsyncRead`] support
-pub struct StreamDecoderRead<R> {
+#[derive(Default)]
+pub struct StreamDecoderRead {
     dec: CoreVecDecoderBytes,
-    deferred: Option<DeferredFn<Incoming<R>>>,
+    deferred: Option<DeferredFn<Incoming>>,
 }
 
-impl<R> Default for StreamDecoderRead<R> {
-    fn default() -> Self {
-        Self {
-            dec: CoreVecDecoderBytes::default(),
-            deferred: None,
-        }
-    }
-}
-
-impl<R> Deferred<Incoming<R>> for StreamDecoderRead<R> {
-    fn take_deferred(&mut self) -> Option<DeferredFn<Incoming<R>>> {
+impl Deferred<Incoming> for StreamDecoderRead {
+    fn take_deferred(&mut self) -> Option<DeferredFn<Incoming>> {
         self.deferred.take()
     }
 }
 
-impl<R> tokio_util::codec::Decoder for StreamDecoderRead<R>
-where
-    R: AsyncRead + crate::Index<R> + Send + Sync + Unpin + 'static,
-{
+impl tokio_util::codec::Decoder for StreamDecoderRead {
     type Item = Pin<Box<dyn AsyncRead + Send>>;
     type Error = std::io::Error;
 
@@ -2325,12 +2252,9 @@ where
     }
 }
 
-impl<R> Decode<R> for Pin<Box<dyn AsyncRead + Send>>
-where
-    R: AsyncRead + crate::Index<R> + Send + Sync + Unpin + 'static,
-{
-    type Decoder = StreamDecoderRead<R>;
-    type ListDecoder = ListDecoder<Self::Decoder, R>;
+impl Decode for Pin<Box<dyn AsyncRead + Send>> {
+    type Decoder = StreamDecoderRead;
+    type ListDecoder = ListDecoder<Self::Decoder>;
 }
 
 #[cfg(test)]
@@ -2339,20 +2263,12 @@ mod tests {
 
     use super::*;
 
-    struct NoopStream;
-
-    impl crate::Index<Self> for NoopStream {
-        fn index(&self, path: &[usize]) -> anyhow::Result<Self> {
-            panic!("index should not be called with path {path:?}")
-        }
-    }
-
     #[test_log::test(tokio::test)]
     async fn codec() -> anyhow::Result<()> {
         let mut buf = BytesMut::new();
-        let mut enc = <(u8, u32) as Encode<NoopStream>>::Encoder::default();
+        let mut enc = <(u8, u32) as Encode>::Encoder::default();
         enc.encode((0x42, 0x42), &mut buf)?;
-        if let Some(_f) = Deferred::<NoopStream>::take_deferred(&mut enc) {
+        if let Some(_f) = Deferred::<Outgoing>::take_deferred(&mut enc) {
             bail!("no deferred write should have been returned");
         }
         assert_eq!(buf.as_ref(), b"\x42\x42");
@@ -2361,7 +2277,7 @@ mod tests {
 
     #[test]
     fn canonical_nan_f32() {
-        let mut enc = <f32 as Encode<NoopStream>>::Encoder::default();
+        let mut enc = <f32 as Encode>::Encoder::default();
 
         // A non-canonical (e.g. signalling) `NaN` is canonicalized on encode.
         let mut buf = BytesMut::new();
@@ -2381,7 +2297,7 @@ mod tests {
 
     #[test]
     fn canonical_nan_f64() {
-        let mut enc = <f64 as Encode<NoopStream>>::Encoder::default();
+        let mut enc = <f64 as Encode>::Encoder::default();
 
         let mut buf = BytesMut::new();
         enc.encode(f64::from_bits(0x7ff0_0000_0000_0001), &mut buf)

--- a/crates/wasmtime/src/codec.rs
+++ b/crates/wasmtime/src/codec.rs
@@ -123,7 +123,7 @@ where
     let mut futs: FuturesUnordered<_> = zip(0.., deferred)
         .filter_map(|(i, f)| f.map(|f| (w.index(&[i]), f)))
         .map(|(w, f)| async move {
-            let w = w.map_err(wasmtime::Error::from_anyhow)?;
+            let w = w.map_err(wasmtime::Error::from)?;
             f(w).await
         })
         .collect();

--- a/crates/wasmtime/src/codec.rs
+++ b/crates/wasmtime/src/codec.rs
@@ -8,7 +8,7 @@ use std::collections::HashSet;
 use bytes::{BufMut as _, BytesMut};
 use futures::TryStreamExt as _;
 use futures::stream::FuturesUnordered;
-use tokio::io::{AsyncRead, AsyncReadExt as _, AsyncWrite, AsyncWriteExt as _};
+use tokio::io::{AsyncRead, AsyncReadExt as _, AsyncWriteExt as _};
 use tokio_util::codec::{Encoder, FramedRead};
 use tokio_util::compat::FuturesAsyncReadCompatExt as _;
 use tracing::{error, instrument, trace, warn};
@@ -26,10 +26,11 @@ use wasmtime::{AsContextMut, StoreContextMut};
 use wasmtime_wasi::p2::pipe::AsyncReadStream;
 use wasmtime_wasi::p2::{DynInputStream, StreamError};
 use wrpc_transport::ListDecoderU8;
+use wrpc_transport::frame::{Incoming, Outgoing};
 
 use crate::{RemoteResource, WrpcView};
 
-pub struct ValEncoder<'a, T: 'static, W> {
+pub struct ValEncoder<'a, T: 'static> {
     pub store: StoreContextMut<'a, T>,
     pub ty: &'a Type,
     pub resources: &'a [ResourceType],
@@ -37,18 +38,21 @@ pub struct ValEncoder<'a, T: 'static, W> {
     /// `output-stream`), identified by their possibly-uninstantiated type.
     pub io_streams: &'a [ResourceType],
     pub deferred: Option<
-        Box<dyn FnOnce(W) -> Pin<Box<dyn Future<Output = wasmtime::Result<()>> + Send>> + Send>,
+        Box<
+            dyn FnOnce(Outgoing) -> Pin<Box<dyn Future<Output = wasmtime::Result<()>> + Send>>
+                + Send,
+        >,
     >,
 }
 
-impl<T, W> ValEncoder<'_, T, W> {
+impl<T> ValEncoder<'_, T> {
     #[must_use]
     pub fn new<'a>(
         store: StoreContextMut<'a, T>,
         ty: &'a Type,
         resources: &'a [ResourceType],
         io_streams: &'a [ResourceType],
-    ) -> ValEncoder<'a, T, W> {
+    ) -> ValEncoder<'a, T> {
         ValEncoder {
             store,
             ty,
@@ -58,7 +62,7 @@ impl<T, W> ValEncoder<'_, T, W> {
         }
     }
 
-    pub fn with_type<'a>(&'a mut self, ty: &'a Type) -> ValEncoder<'a, T, W> {
+    pub fn with_type<'a>(&'a mut self, ty: &'a Type) -> ValEncoder<'a, T> {
         ValEncoder {
             store: self.store.as_context_mut(),
             ty,
@@ -104,13 +108,15 @@ fn flag_bits<'a, T: BitOrAssign + Shl<u8, Output = T> + From<u8>>(
     v
 }
 
-async fn write_deferred<W, I>(w: W, deferred: I) -> wasmtime::Result<()>
+async fn write_deferred<I>(w: Outgoing, deferred: I) -> wasmtime::Result<()>
 where
-    W: wrpc_transport::Index<W> + Sync + Send + 'static,
     I: IntoIterator,
     I::IntoIter: ExactSizeIterator<
         Item = Option<
-            Box<dyn FnOnce(W) -> Pin<Box<dyn Future<Output = wasmtime::Result<()>> + Send>> + Send>,
+            Box<
+                dyn FnOnce(Outgoing) -> Pin<Box<dyn Future<Output = wasmtime::Result<()>> + Send>>
+                    + Send,
+            >,
         >,
     >,
 {
@@ -125,10 +131,9 @@ where
     Ok(())
 }
 
-impl<T, W> Encoder<&Val> for ValEncoder<'_, T, W>
+impl<T> Encoder<&Val> for ValEncoder<'_, T>
 where
     T: WrpcView,
-    W: AsyncWrite + wrpc_transport::Index<W> + Sync + Send + 'static,
 {
     type Error = wasmtime::Error;
 
@@ -558,9 +563,9 @@ async fn read_flags(n: usize, r: &mut (impl AsyncRead + Unpin)) -> std::io::Resu
 /// Read encoded value of type [`Type`] from an [`AsyncRead`] into a [`Val`]
 #[instrument(level = "trace", skip_all, fields(ty, path))]
 #[allow(clippy::too_many_arguments)]
-pub async fn read_value<T, R>(
+pub async fn read_value<T>(
     store: &mut impl AsContextMut<Data = T>,
-    r: &mut Pin<&mut R>,
+    r: &mut Pin<&mut Incoming>,
     resources: &[ResourceType],
     io_streams: &[ResourceType],
     val: &mut Val,
@@ -569,7 +574,6 @@ pub async fn read_value<T, R>(
 ) -> std::io::Result<()>
 where
     T: WrpcView + 'static,
-    R: AsyncRead + wrpc_transport::Index<R> + Send + Unpin + 'static,
 {
     match ty {
         Type::Bool => {

--- a/crates/wasmtime/src/lib.rs
+++ b/crates/wasmtime/src/lib.rs
@@ -460,7 +460,7 @@ where
         zip(0.., deferred)
             .filter_map(|(i, f)| f.map(|f| (tx.index(&[i]), f)))
             .map(|(w, f)| async move {
-                let w = w.map_err(wasmtime::Error::from_anyhow)?;
+                let w = w.map_err(wasmtime::Error::from)?;
                 f(w).await
             }),
     )

--- a/crates/wasmtime/src/lib.rs
+++ b/crates/wasmtime/src/lib.rs
@@ -14,7 +14,7 @@ use std::sync::Arc;
 use anyhow::anyhow;
 use bytes::{Bytes, BytesMut};
 use futures::future::try_join_all;
-use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt as _};
+use tokio::io::AsyncWriteExt as _;
 use tokio_util::codec::Encoder;
 use tracing::{debug, instrument, trace, warn};
 use uuid::Uuid;
@@ -24,6 +24,7 @@ use wasmtime::component::{
 use wasmtime::error::Context as _;
 use wasmtime::{AsContextMut, Engine, bail};
 use wrpc_transport::Invoke;
+use wrpc_transport::frame::{Incoming, Outgoing};
 
 use crate::bindings::rpc::context::Context;
 use crate::bindings::rpc::error::Error;
@@ -123,13 +124,7 @@ impl<T: WrpcView> WrpcView for &mut T {
 pub trait WrpcViewExt: WrpcView {
     fn push_invocation(
         &mut self,
-        invocation: impl Future<
-            Output = anyhow::Result<(
-                <Self::Invoke as Invoke>::Outgoing,
-                <Self::Invoke as Invoke>::Incoming,
-            )>,
-        > + Send
-        + 'static,
+        invocation: impl Future<Output = anyhow::Result<(Outgoing, Incoming)>> + Send + 'static,
     ) -> wasmtime::Result<Resource<Invocation>> {
         self.wrpc()
             .table
@@ -143,16 +138,7 @@ pub trait WrpcViewExt: WrpcView {
     fn get_invocation_result(
         &mut self,
         invocation: &Resource<Invocation>,
-    ) -> wasmtime::Result<
-        Option<
-            &Box<
-                anyhow::Result<(
-                    <Self::Invoke as Invoke>::Outgoing,
-                    <Self::Invoke as Invoke>::Incoming,
-                )>,
-            >,
-        >,
-    > {
+    ) -> wasmtime::Result<Option<&Box<anyhow::Result<(Outgoing, Incoming)>>>> {
         let invocation = self
             .wrpc()
             .table
@@ -170,14 +156,7 @@ pub trait WrpcViewExt: WrpcView {
     fn delete_invocation(
         &mut self,
         invocation: Resource<Invocation>,
-    ) -> wasmtime::Result<
-        impl Future<
-            Output = anyhow::Result<(
-                <Self::Invoke as Invoke>::Outgoing,
-                <Self::Invoke as Invoke>::Incoming,
-            )>,
-        >,
-    > {
+    ) -> wasmtime::Result<impl Future<Output = anyhow::Result<(Outgoing, Incoming)>>> {
         let invocation = self
             .wrpc()
             .table
@@ -197,7 +176,7 @@ pub trait WrpcViewExt: WrpcView {
 
     fn push_outgoing_channel(
         &mut self,
-        outgoing: <Self::Invoke as Invoke>::Outgoing,
+        outgoing: Outgoing,
     ) -> wasmtime::Result<Resource<OutgoingChannel>> {
         self.wrpc()
             .table
@@ -210,7 +189,7 @@ pub trait WrpcViewExt: WrpcView {
     fn delete_outgoing_channel(
         &mut self,
         outgoing: Resource<OutgoingChannel>,
-    ) -> wasmtime::Result<<Self::Invoke as Invoke>::Outgoing> {
+    ) -> wasmtime::Result<Outgoing> {
         let OutgoingChannel(outgoing) = self
             .wrpc()
             .table
@@ -229,7 +208,7 @@ pub trait WrpcViewExt: WrpcView {
 
     fn push_incoming_channel(
         &mut self,
-        incoming: <Self::Invoke as Invoke>::Incoming,
+        incoming: Incoming,
     ) -> wasmtime::Result<Resource<IncomingChannel>> {
         self.wrpc()
             .table
@@ -242,7 +221,7 @@ pub trait WrpcViewExt: WrpcView {
     fn delete_incoming_channel(
         &mut self,
         incoming: Resource<IncomingChannel>,
-    ) -> wasmtime::Result<<Self::Invoke as Invoke>::Incoming> {
+    ) -> wasmtime::Result<Incoming> {
         let IncomingChannel(incoming) = self
             .wrpc()
             .table
@@ -378,10 +357,10 @@ impl fmt::Display for CallError {
 }
 
 #[allow(clippy::too_many_arguments)]
-pub async fn call<C, I, O>(
+pub async fn call<C>(
     mut store: C,
-    rx: I,
-    mut tx: O,
+    rx: Incoming,
+    mut tx: Outgoing,
     guest_resources: &[ResourceType],
     host_resources: &HashMap<Box<str>, HashMap<Box<str>, (ResourceType, ResourceType)>>,
     io_streams: &[ResourceType],
@@ -390,8 +369,6 @@ pub async fn call<C, I, O>(
     func: Func,
 ) -> Result<(), CallError>
 where
-    I: AsyncRead + wrpc_transport::Index<I> + Send + Sync + Unpin + 'static,
-    O: AsyncWrite + wrpc_transport::Index<O> + Send + Sync + Unpin + 'static,
     C: AsContextMut,
     C::Data: WrpcView,
 {

--- a/crates/wasmtime/src/polyfill.rs
+++ b/crates/wasmtime/src/polyfill.rs
@@ -14,7 +14,7 @@ use tracing::{Instrument as _, Span, debug, instrument, trace, warn};
 use wasmtime::component::{LinkerInstance, ResourceType, Type, Val, types};
 use wasmtime::error::Context as _;
 use wasmtime::{AsContextMut, Engine, StoreContextMut, bail, ensure};
-use wrpc_transport::{Index as _, Invoke, InvokeExt as _};
+use wrpc_transport::{Invoke, InvokeExt as _};
 
 use crate::rpc::Error;
 use crate::{ValEncoder, WrpcView, WrpcViewExt as _, read_value, rpc_func_name, rpc_result_type};

--- a/crates/wasmtime/src/polyfill.rs
+++ b/crates/wasmtime/src/polyfill.rs
@@ -179,7 +179,7 @@ async fn invoke<T: WrpcView>(
             zip(0.., deferred)
                 .filter_map(|(i, f)| f.map(|f| (outgoing.index(&[i]), f)))
                 .map(|(w, f)| async move {
-                    let w = w.map_err(wasmtime::Error::from_anyhow)?;
+                    let w = w.map_err(wasmtime::Error::from)?;
                     f(w).await
                 }),
         )

--- a/crates/wasmtime/src/rpc/host/transport.rs
+++ b/crates/wasmtime/src/rpc/host/transport.rs
@@ -9,7 +9,7 @@ use wasmtime_wasi::p2::bindings::io::poll::Pollable;
 use wasmtime_wasi::p2::bindings::io::streams::{InputStream, OutputStream};
 use wasmtime_wasi::p2::pipe::{AsyncReadStream, AsyncWriteStream};
 use wasmtime_wasi::p2::subscribe;
-use wrpc_transport::{Index as _, Invoke};
+use wrpc_transport::frame::{Incoming, Outgoing};
 
 use crate::bindings::rpc::error::Error;
 use crate::bindings::rpc::transport::{
@@ -77,7 +77,7 @@ impl<T: WrpcView> HostIncomingChannel for WrpcRpcImpl<T> {
             .push_child(
                 Box::new(AsyncReadStream::new(IncomingChannelStream {
                     incoming: IncomingChannel(stream),
-                    _ty: PhantomData::<<T::Invoke as Invoke>::Incoming>,
+                    _ty: PhantomData::<Incoming>,
                 })) as InputStream,
                 &incoming,
             )
@@ -106,7 +106,7 @@ impl<T: WrpcView> HostIncomingChannel for WrpcRpcImpl<T> {
                 bail!("lock poisoned");
             };
             let incoming = incoming
-                .downcast_ref::<<T::Invoke as Invoke>::Incoming>()
+                .downcast_ref::<Incoming>()
                 .context("invalid incoming channel type")?;
             incoming.index(&path)
         };
@@ -152,7 +152,7 @@ impl<T: WrpcView> HostOutgoingChannel for WrpcRpcImpl<T> {
                     8192,
                     OutgoingChannelStream {
                         outgoing: OutgoingChannel(stream),
-                        _ty: PhantomData::<<T::Invoke as Invoke>::Outgoing>,
+                        _ty: PhantomData::<Outgoing>,
                     },
                 )) as OutputStream,
                 &outgoing,
@@ -182,7 +182,7 @@ impl<T: WrpcView> HostOutgoingChannel for WrpcRpcImpl<T> {
                 bail!("lock poisoned");
             };
             let outgoing = outgoing
-                .downcast_ref::<<T::Invoke as Invoke>::Outgoing>()
+                .downcast_ref::<Outgoing>()
                 .context("invalid outgoing channel type")?;
             outgoing.index(&path)
         };

--- a/crates/wasmtime/src/rpc/mod.rs
+++ b/crates/wasmtime/src/rpc/mod.rs
@@ -50,10 +50,10 @@ pub enum Error {
     Invoke(anyhow::Error),
     /// Error originating from an [`index`](wrpc_transport::frame::Incoming::index) call on the
     /// incoming framed stream.
-    IncomingIndex(anyhow::Error),
+    IncomingIndex(std::io::Error),
     /// Error originating from an [`index`](wrpc_transport::frame::Outgoing::index) call on the
     /// outgoing framed stream.
-    OutgoingIndex(anyhow::Error),
+    OutgoingIndex(std::io::Error),
     /// Error originating from a `wasi:io` stream provided by this crate.
     Stream(StreamError),
 }
@@ -61,9 +61,8 @@ pub enum Error {
 impl fmt::Debug for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Error::Invoke(error) | Error::IncomingIndex(error) | Error::OutgoingIndex(error) => {
-                error.fmt(f)
-            }
+            Error::Invoke(error) => error.fmt(f),
+            Error::IncomingIndex(error) | Error::OutgoingIndex(error) => error.fmt(f),
             Error::Stream(error) => error.fmt(f),
         }
     }
@@ -72,9 +71,8 @@ impl fmt::Debug for Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Error::Invoke(error) | Error::IncomingIndex(error) | Error::OutgoingIndex(error) => {
-                error.fmt(f)
-            }
+            Error::Invoke(error) => error.fmt(f),
+            Error::IncomingIndex(error) | Error::OutgoingIndex(error) => error.fmt(f),
             Error::Stream(error) => error.fmt(f),
         }
     }

--- a/crates/wasmtime/src/rpc/mod.rs
+++ b/crates/wasmtime/src/rpc/mod.rs
@@ -48,10 +48,11 @@ where
 pub enum Error {
     /// Error originating from [Invoke::invoke] call
     Invoke(anyhow::Error),
-    /// Error originating from [Index::index](wrpc_transport::Index::index) call on [Invoke::Incoming].
+    /// Error originating from an [`index`](wrpc_transport::frame::Incoming::index) call on the
+    /// incoming framed stream.
     IncomingIndex(anyhow::Error),
-    /// Error originating from [Index::index](wrpc_transport::Index::index) call on
-    /// [Invoke::Outgoing].
+    /// Error originating from an [`index`](wrpc_transport::frame::Outgoing::index) call on the
+    /// outgoing framed stream.
     OutgoingIndex(anyhow::Error),
     /// Error originating from a `wasi:io` stream provided by this crate.
     Stream(StreamError),

--- a/crates/wave/src/pack.rs
+++ b/crates/wave/src/pack.rs
@@ -7,8 +7,8 @@ use bytes::BytesMut;
 use tokio_util::codec::Encoder;
 use wasm_wave::value::{Type, Value};
 use wasm_wave::wasm::{WasmType, WasmValue};
-use wrpc_pack::NoopStream;
 use wrpc_transport::Deferred;
+use wrpc_transport::frame::Outgoing;
 
 use crate::core::encode::WaveEncoder;
 
@@ -20,9 +20,9 @@ use crate::core::encode::WaveEncoder;
 #[derive(Debug, Default)]
 pub struct TypedWaveEncoder;
 
-impl Deferred<NoopStream> for TypedWaveEncoder {
-    fn take_deferred(&mut self) -> Option<wrpc_transport::DeferredFn<NoopStream>> {
-        // NoopStream doesn't support async operations, so we never have deferred values
+impl Deferred<Outgoing> for TypedWaveEncoder {
+    fn take_deferred(&mut self) -> Option<wrpc_transport::DeferredFn<Outgoing>> {
+        // wave values are always fully synchronous, so we never have deferred values
         None
     }
 }
@@ -91,7 +91,7 @@ impl<V: WasmValue, T: WasmType> From<WasmTypedValue<V, T>> for (V, T) {
 }
 
 // Generic implementations for wrpc_transport::Encode
-impl<V, T> wrpc_transport::Encode<NoopStream> for WasmTypedValue<V, T>
+impl<V, T> wrpc_transport::Encode for WasmTypedValue<V, T>
 where
     V: WasmValue<Type = T>,
     T: WasmType,
@@ -99,7 +99,7 @@ where
     type Encoder = TypedWaveEncoder;
 }
 
-impl<V, T> wrpc_transport::Encode<NoopStream> for &WasmTypedValue<V, T>
+impl<V, T> wrpc_transport::Encode for &WasmTypedValue<V, T>
 where
     V: WasmValue<Type = T>,
     T: WasmType,

--- a/crates/websockets/src/lib.rs
+++ b/crates/websockets/src/lib.rs
@@ -136,8 +136,6 @@ impl<'a, R: Resolver> From<ClientBuilder<'a, R>> for Client<'a, R> {
 
 impl<R: Resolver + Send + Sync> Invoke for Client<'_, R> {
     type Context = ();
-    type Outgoing = wrpc_transport::frame::Outgoing;
-    type Incoming = wrpc_transport::frame::Incoming;
 
     #[instrument(level = "trace", skip(self, paths, params), fields(params = format!("{params:02x?}")))]
     async fn invoke<P>(
@@ -147,7 +145,10 @@ impl<R: Resolver + Send + Sync> Invoke for Client<'_, R> {
         func: &str,
         params: Bytes,
         paths: impl AsRef<[P]> + Send,
-    ) -> anyhow::Result<(Self::Outgoing, Self::Incoming)>
+    ) -> anyhow::Result<(
+        wrpc_transport::frame::Outgoing,
+        wrpc_transport::frame::Incoming,
+    )>
     where
         P: AsRef<[Option<usize>]> + Send + Sync,
     {

--- a/crates/webtransport/src/lib.rs
+++ b/crates/webtransport/src/lib.rs
@@ -80,8 +80,6 @@ impl wrpc_transport::frame::ConnHandler<RecvStream, SendStream> for ConnHandler 
 
 impl Invoke for &Client {
     type Context = ();
-    type Outgoing = Outgoing;
-    type Incoming = Incoming;
 
     async fn invoke<P>(
         &self,
@@ -90,7 +88,7 @@ impl Invoke for &Client {
         func: &str,
         params: Bytes,
         paths: impl AsRef<[P]> + Send,
-    ) -> anyhow::Result<(Self::Outgoing, Self::Incoming)>
+    ) -> anyhow::Result<(Outgoing, Incoming)>
     where
         P: AsRef<[Option<usize>]> + Send + Sync,
     {
@@ -106,8 +104,6 @@ impl Invoke for &Client {
 
 impl Invoke for Client {
     type Context = ();
-    type Outgoing = Outgoing;
-    type Incoming = Incoming;
 
     async fn invoke<P>(
         &self,
@@ -116,7 +112,7 @@ impl Invoke for Client {
         func: &str,
         params: Bytes,
         paths: impl AsRef<[P]> + Send,
-    ) -> anyhow::Result<(Self::Outgoing, Self::Incoming)>
+    ) -> anyhow::Result<(Outgoing, Incoming)>
     where
         P: AsRef<[Option<usize>]> + Send + Sync,
     {

--- a/crates/wit-bindgen-rust/src/interface.rs
+++ b/crates/wit-bindgen-rust/src/interface.rs
@@ -1264,36 +1264,28 @@ impl<'a> wit_bindgen_core::InterfaceGenerator<'a> for InterfaceGenerator<'a> {
                 uwriteln!(
                     self.src,
                     r"
-impl<W> {wrpc_transport}::Encode<W> for &self::{name}
-where
-    W: ::core::marker::Send + ::core::marker::Sync + {wrpc_transport}::Index<W> + {tokio}::io::AsyncWrite + ::core::marker::Unpin + 'static,
+impl {wrpc_transport}::Encode for &self::{name}
 {{
-    type Encoder = {mod_name}::Encoder<W>;
+    type Encoder = {mod_name}::Encoder;
 }}",
                 );
             }
             uwriteln!(
                 self.src,
                 r"
-impl<W> {wrpc_transport}::Encode<W> for self::{name}
-where
-    W: ::core::marker::Send + ::core::marker::Sync + {wrpc_transport}::Index<W> + {tokio}::io::AsyncWrite + ::core::marker::Unpin + 'static,
+impl {wrpc_transport}::Encode for self::{name}
 {{
-    type Encoder = {mod_name}::Encoder<W>;
+    type Encoder = {mod_name}::Encoder;
 }}
 
-impl<R> {wrpc_transport}::Decode<R> for self::{name}
-where
-    R: ::core::marker::Send + ::core::marker::Sync + {wrpc_transport}::Index<R> + {tokio}::io::AsyncRead + ::core::marker::Unpin + 'static,
+impl {wrpc_transport}::Decode for self::{name}
 {{
-    type Decoder = {mod_name}::Decoder<R>;
-    type ListDecoder = {wrpc_transport}::ListDecoder<Self::Decoder, R>;
+    type Decoder = {mod_name}::Decoder;
+    type ListDecoder = {wrpc_transport}::ListDecoder<Self::Decoder>;
 }}
 
 mod {mod_name} {{
-    pub struct Encoder<W> 
-    where
-        W: ::core::marker::Send + ::core::marker::Sync + {wrpc_transport}::Index<W> + {tokio}::io::AsyncWrite + ::core::marker::Unpin + 'static,
+    pub struct Encoder 
     {{",
             );
 
@@ -1302,18 +1294,16 @@ mod {mod_name} {{
                     let name = to_rust_ident(name);
                     uwrite!(self.src, "{name}: <");
                     self.print_ty(ty, true, true);
-                    uwriteln!(self.src, " as {wrpc_transport}::Encode<W>>::Encoder,");
+                    uwriteln!(self.src, " as {wrpc_transport}::Encode>::Encoder,");
                 }
             } else {
-                uwriteln!(self.src, "_ty: ::core::marker::PhantomData<W>,");
+                uwriteln!(self.src, "_ty: ::core::marker::PhantomData<()>,");
             }
             uwriteln!(
                 self.src,
                 r"}}
     #[automatically_derived]
-    impl<W> ::core::default::Default for Encoder<W>
-    where
-        W: ::core::marker::Send + ::core::marker::Sync + {wrpc_transport}::Index<W> + {tokio}::io::AsyncWrite + ::core::marker::Unpin + 'static,
+    impl ::core::default::Default for Encoder
     {{
         fn default() -> Self {{
             Self{{"
@@ -1333,11 +1323,9 @@ mod {mod_name} {{
     }}
 
     #[automatically_derived]
-    impl<W> {wrpc_transport}::Deferred<W> for Encoder<W>
-    where
-        W: ::core::marker::Send + ::core::marker::Sync + {wrpc_transport}::Index<W> + {tokio}::io::AsyncWrite + ::core::marker::Unpin + 'static,
+    impl {wrpc_transport}::Deferred<{wrpc_transport}::frame::Outgoing> for Encoder
     {{
-        fn take_deferred(&mut self) -> ::core::option::Option<{wrpc_transport}::DeferredFn<W>> {{"
+        fn take_deferred(&mut self) -> ::core::option::Option<{wrpc_transport}::DeferredFn<{wrpc_transport}::frame::Outgoing>> {{"
             );
             if !fields.is_empty() {
                 for Field { name, .. } in fields {
@@ -1362,7 +1350,7 @@ mod {mod_name} {{
                         r"
                         let f_{name} = f_{name}.map(|f| {{
                             path.push({i});
-                            let w = {wrpc_transport}::Index::index(&w, &path);
+                            let w = w.index(&path);
                             path.pop();
                             (f, w)
                         }});"
@@ -1405,9 +1393,7 @@ mod {mod_name} {{
         }}
     }}
 
-    pub struct Decoder<R>
-    where
-        R: ::core::marker::Send + ::core::marker::Sync + {wrpc_transport}::Index<R> + {tokio}::io::AsyncRead + ::core::marker::Unpin + 'static,
+    pub struct Decoder
     {{"
             );
 
@@ -1416,21 +1402,19 @@ mod {mod_name} {{
                     let name = to_rust_ident(name);
                     uwrite!(self.src, "c_{name}: <");
                     self.print_ty(ty, true, true);
-                    uwriteln!(self.src, " as {wrpc_transport}::Decode<R>>::Decoder,");
+                    uwriteln!(self.src, " as {wrpc_transport}::Decode>::Decoder,");
                     uwrite!(self.src, "v_{name}: ::core::option::Option<");
                     self.print_ty(ty, true, true);
                     uwriteln!(self.src, ">,");
                 }
             } else {
-                uwriteln!(self.src, "_ty: ::core::marker::PhantomData<R>,");
+                uwriteln!(self.src, "_ty: ::core::marker::PhantomData<()>,");
             }
             uwriteln!(
                 self.src,
                 r"}}
     #[automatically_derived]
-    impl<R> ::core::default::Default for Decoder<R>
-    where
-        R: ::core::marker::Send + ::core::marker::Sync + {wrpc_transport}::Index<R> + {tokio}::io::AsyncRead + ::core::marker::Unpin + 'static,
+    impl ::core::default::Default for Decoder
     {{
         fn default() -> Self {{
             Self{{"
@@ -1451,11 +1435,9 @@ mod {mod_name} {{
     }}
 
     #[automatically_derived]
-    impl<R> {wrpc_transport}::Deferred<{wrpc_transport}::Incoming<R>> for Decoder<R>
-    where
-        R: ::core::marker::Send + ::core::marker::Sync + {wrpc_transport}::Index<R> + {tokio}::io::AsyncRead + ::core::marker::Unpin + 'static,
+    impl {wrpc_transport}::Deferred<{wrpc_transport}::Incoming> for Decoder
     {{
-        fn take_deferred(&mut self) -> ::core::option::Option<{wrpc_transport}::DeferredFn<{wrpc_transport}::Incoming<R>>> {{"
+        fn take_deferred(&mut self) -> ::core::option::Option<{wrpc_transport}::DeferredFn<{wrpc_transport}::Incoming>> {{"
             );
             if !fields.is_empty() {
                 for Field { name, .. } in fields {
@@ -1480,7 +1462,7 @@ mod {mod_name} {{
                         r"
                         let f_{name} = f_{name}.map(|f| {{
                             path.push({i});
-                            let r = {wrpc_transport}::Index::index(&r, &path);
+                            let r = r.index(&path);
                             path.pop();
                             (f, r)
                         }});"
@@ -1524,9 +1506,7 @@ mod {mod_name} {{
     }}
 
     #[automatically_derived]
-    impl<R> {tokio_util}::codec::Decoder for Decoder<R> 
-    where
-        R: ::core::marker::Send + ::core::marker::Sync + {wrpc_transport}::Index<R> + {tokio}::io::AsyncRead + ::core::marker::Unpin + 'static,
+    impl {tokio_util}::codec::Decoder for Decoder 
     {{
         type Item = super::{name};
         type Error = ::std::io::Error;
@@ -1564,9 +1544,7 @@ mod {mod_name} {{
                     self.src,
                     r#"
     #[automatically_derived]
-    impl<W> {tokio_util}::codec::Encoder<{name}> for Encoder<W> 
-    where
-        W: ::core::marker::Send + ::core::marker::Sync + {wrpc_transport}::Index<W> + {tokio}::io::AsyncWrite + ::core::marker::Unpin + 'static,
+    impl {tokio_util}::codec::Encoder<{name}> for Encoder 
     {{
         type Error = ::std::io::Error;
 
@@ -1699,19 +1677,19 @@ pub struct {}(());",
             uwriteln!(
                 self.src,
                 r#"
-impl<W> {wrpc_transport}::Encode<W> for self::{name} {{
+impl {wrpc_transport}::Encode for self::{name} {{
     type Encoder = {mod_name}::Codec;
 }}
 
-impl<W> {wrpc_transport}::Encode<W> for &self::{name} {{
+impl {wrpc_transport}::Encode for &self::{name} {{
     type Encoder = {mod_name}::Codec;
 }}
 
-impl<W> {wrpc_transport}::Encode<W> for &&self::{name} {{
+impl {wrpc_transport}::Encode for &&self::{name} {{
     type Encoder = {mod_name}::Codec;
 }}
 
-impl<R> {wrpc_transport}::Decode<R> for self::{name} {{
+impl {wrpc_transport}::Decode for self::{name} {{
     type Decoder = {mod_name}::Codec;
     type ListDecoder = {wrpc_transport}::SyncCodec<{wasm_tokio}::CoreVecDecoder<Self::Decoder>>;
 }}
@@ -1875,19 +1853,19 @@ mod {mod_name} {{
                 uwriteln!(
                     self.src,
                     r#"
-impl<W> {wrpc_transport}::Encode<W> for self::{name} {{
+impl {wrpc_transport}::Encode for self::{name} {{
     type Encoder = {mod_name}::Codec;
 }}
 
-impl<W> {wrpc_transport}::Encode<W> for &self::{name} {{
+impl {wrpc_transport}::Encode for &self::{name} {{
     type Encoder = {mod_name}::Codec;
 }}
 
-impl<W> {wrpc_transport}::Encode<W> for &&self::{name} {{
+impl {wrpc_transport}::Encode for &&self::{name} {{
     type Encoder = {mod_name}::Codec;
 }}
 
-impl<R> {wrpc_transport}::Decode<R> for self::{name} {{
+impl {wrpc_transport}::Decode for self::{name} {{
     type Decoder = {mod_name}::Codec;
     type ListDecoder = {wrpc_transport}::SyncCodec<{wasm_tokio}::CoreVecDecoder<Self::Decoder>>;
 }}
@@ -1963,25 +1941,19 @@ mod {mod_name} {{
 }}"#,
                 );
             } else {
-                let tokio = self.r#gen.tokio_path().to_string();
-
                 let (paths, _) = async_paths_tyid(self.resolve, id);
                 if paths.is_empty() {
                     uwrite!(
                         self.src,
                         r#"
-impl<W> {wrpc_transport}::Encode<W> for &self::{name}
-where
-    W: ::core::marker::Send + ::core::marker::Sync + {wrpc_transport}::Index<W> + {tokio}::io::AsyncWrite + ::core::marker::Unpin + 'static,
+impl {wrpc_transport}::Encode for &self::{name}
 {{
-    type Encoder = {mod_name}::Encoder<W>;
+    type Encoder = {mod_name}::Encoder;
 }}
 
-impl<W> {wrpc_transport}::Encode<W> for &&self::{name}
-where
-    W: ::core::marker::Send + ::core::marker::Sync + {wrpc_transport}::Index<W> + {tokio}::io::AsyncWrite + ::core::marker::Unpin + 'static,
+impl {wrpc_transport}::Encode for &&self::{name}
 {{
-    type Encoder = {mod_name}::Encoder<W>;
+    type Encoder = {mod_name}::Encoder;
 }}
 "#
                     );
@@ -1990,34 +1962,30 @@ where
                 uwrite!(
                     self.src,
                     r#"
-impl<W> {wrpc_transport}::Encode<W> for self::{name}
-where
-    W: ::core::marker::Send + ::core::marker::Sync + {wrpc_transport}::Index<W> + {tokio}::io::AsyncWrite + ::core::marker::Unpin + 'static,
+impl {wrpc_transport}::Encode for self::{name}
 {{
-    type Encoder = {mod_name}::Encoder<W>;
+    type Encoder = {mod_name}::Encoder;
 }}
 
-impl<R> {wrpc_transport}::Decode<R> for self::{name}
-where
-    R: ::core::marker::Send + ::core::marker::Sync + {wrpc_transport}::Index<R> + {tokio}::io::AsyncRead + ::core::marker::Unpin + 'static,
+impl {wrpc_transport}::Decode for self::{name}
 {{
-    type Decoder = {mod_name}::Decoder<R>;
-    type ListDecoder = {wrpc_transport}::ListDecoder<Self::Decoder, R>;
+    type Decoder = {mod_name}::Decoder;
+    type ListDecoder = {wrpc_transport}::ListDecoder<Self::Decoder>;
 }}
 
 mod {mod_name} {{
-    pub struct Encoder<W>(::core::option::Option<{wrpc_transport}::DeferredFn<W>>);
+    pub struct Encoder(::core::option::Option<{wrpc_transport}::DeferredFn<{wrpc_transport}::frame::Outgoing>>);
 
     #[automatically_derived]
-    impl<W> ::core::default::Default for Encoder<W> {{
+    impl ::core::default::Default for Encoder {{
         fn default() -> Self {{ 
             Self(None)
         }}
     }}
 
     #[automatically_derived]
-    impl<W> {wrpc_transport}::Deferred<W> for Encoder<W> {{
-        fn take_deferred(&mut self) -> ::core::option::Option<{wrpc_transport}::DeferredFn<W>> {{
+    impl {wrpc_transport}::Deferred<{wrpc_transport}::frame::Outgoing> for Encoder {{
+        fn take_deferred(&mut self) -> ::core::option::Option<{wrpc_transport}::DeferredFn<{wrpc_transport}::frame::Outgoing>> {{
             self.0.take()
         }}
     }}"#
@@ -2035,9 +2003,7 @@ mod {mod_name} {{
                         self.src,
                         r#"
     #[automatically_derived]
-    impl<W> {tokio_util}::codec::Encoder<{ty}> for Encoder<W> 
-    where
-        W: ::core::marker::Send + ::core::marker::Sync + {wrpc_transport}::Index<W> + {tokio}::io::AsyncWrite + ::core::marker::Unpin + 'static,
+    impl {tokio_util}::codec::Encoder<{ty}> for Encoder 
     {{
         type Error = ::std::io::Error;
 
@@ -2060,7 +2026,7 @@ mod {mod_name} {{
                                 r"
                 super::{name}::{case}(payload) => {{
                     {wasm_tokio}::Leb128Encoder.encode({i}_u32, dst)?;
-                    self.0 = {wrpc_transport}::Encode::<W>::encode(payload, &mut ::core::default::Default::default(), dst)?;
+                    self.0 = {wrpc_transport}::Encode::encode(payload, &mut ::core::default::Default::default(), dst)?;
                     Ok(())
                 }},"
                             );
@@ -2084,9 +2050,7 @@ mod {mod_name} {{
                 uwrite!(
                     self.src,
                     r"
-    pub enum PayloadDecoder<R>
-    where
-        R: ::core::marker::Send + ::core::marker::Sync + {wrpc_transport}::Index<R> + {tokio}::io::AsyncRead + ::core::marker::Unpin + 'static,
+    pub enum PayloadDecoder
     {{"
                 );
 
@@ -2104,7 +2068,7 @@ mod {mod_name} {{
                 {case}(<"
                         );
                         self.print_ty(ty, true, true);
-                        uwriteln!(self.src, " as {wrpc_transport}::Decode<R>>::Decoder),");
+                        uwriteln!(self.src, " as {wrpc_transport}::Decode>::Decoder),");
                     }
                 }
 
@@ -2113,18 +2077,14 @@ mod {mod_name} {{
                     r#"
     }}
 
-    pub enum Decoder<R>
-    where
-        R: ::core::marker::Send + ::core::marker::Sync + {wrpc_transport}::Index<R> + {tokio}::io::AsyncRead + ::core::marker::Unpin + 'static,
+    pub enum Decoder
     {{
-        Payload(::core::option::Option<PayloadDecoder<R>>),
-        Deferred(::core::option::Option<{wrpc_transport}::DeferredFn<{wrpc_transport}::Incoming<R>>>)
+        Payload(::core::option::Option<PayloadDecoder>),
+        Deferred(::core::option::Option<{wrpc_transport}::DeferredFn<{wrpc_transport}::Incoming>>)
     }}
 
     #[automatically_derived]
-    impl<R> ::core::default::Default for Decoder<R>
-    where
-        R: ::core::marker::Send + ::core::marker::Sync + {wrpc_transport}::Index<R> + {tokio}::io::AsyncRead + ::core::marker::Unpin + 'static,
+    impl ::core::default::Default for Decoder
     {{
         fn default() -> Self {{
             Self::Payload(None)
@@ -2132,11 +2092,9 @@ mod {mod_name} {{
     }}
 
     #[automatically_derived]
-    impl<R> {wrpc_transport}::Deferred<{wrpc_transport}::Incoming<R>> for Decoder<R>
-    where
-        R: ::core::marker::Send + ::core::marker::Sync + {wrpc_transport}::Index<R> + {tokio}::io::AsyncRead + ::core::marker::Unpin + 'static,
+    impl {wrpc_transport}::Deferred<{wrpc_transport}::Incoming> for Decoder
     {{
-        fn take_deferred(&mut self) -> ::core::option::Option<{wrpc_transport}::DeferredFn<{wrpc_transport}::Incoming<R>>> {{
+        fn take_deferred(&mut self) -> ::core::option::Option<{wrpc_transport}::DeferredFn<{wrpc_transport}::Incoming>> {{
             match self {{
                 Self::Payload(None) => None,"#
                 );
@@ -2168,9 +2126,7 @@ mod {mod_name} {{
     }}
 
     #[automatically_derived]
-    impl<R> {tokio_util}::codec::Decoder for Decoder<R> 
-    where
-        R: ::core::marker::Send + ::core::marker::Sync + {wrpc_transport}::Index<R> + {tokio}::io::AsyncRead + ::core::marker::Unpin + 'static,
+    impl {tokio_util}::codec::Decoder for Decoder 
     {{
         type Item = super::{name};
         type Error = ::std::io::Error;
@@ -2238,7 +2194,7 @@ mod {mod_name} {{
                             let Some(payload) = dec.decode(src)? else {{
                                 return Ok(None)
                             }};
-                            *self = Self::Deferred({wrpc_transport}::Deferred::<{wrpc_transport}::Incoming<R>>::take_deferred(dec));
+                            *self = Self::Deferred({wrpc_transport}::Deferred::<{wrpc_transport}::Incoming>::take_deferred(dec));
                             Ok(Some(super::{name}::{case}(payload)))
                         }},"
                         );
@@ -2399,15 +2355,15 @@ mod {mod_name} {{
             uwriteln!(
                 self.src,
                 r#"
-impl<W> {wrpc_transport}::Encode<W> for self::{name} {{
+impl {wrpc_transport}::Encode for self::{name} {{
     type Encoder = {mod_name}::Codec;
 }}
 
-impl<W> {wrpc_transport}::Encode<W> for &self::{name} {{
+impl {wrpc_transport}::Encode for &self::{name} {{
     type Encoder = {mod_name}::Codec;
 }}
 
-impl<R> {wrpc_transport}::Decode<R> for self::{name} {{
+impl {wrpc_transport}::Decode for self::{name} {{
     type Decoder = {mod_name}::Codec;
     type ListDecoder = {wrpc_transport}::SyncCodec<{wasm_tokio}::CoreVecDecoder<Self::Decoder>>;
 }}

--- a/crates/wit-bindgen-rust/src/interface.rs
+++ b/crates/wit-bindgen-rust/src/interface.rs
@@ -1435,9 +1435,9 @@ mod {mod_name} {{
     }}
 
     #[automatically_derived]
-    impl {wrpc_transport}::Deferred<{wrpc_transport}::Incoming> for Decoder
+    impl {wrpc_transport}::Deferred<{wrpc_transport}::BufferedIncoming> for Decoder
     {{
-        fn take_deferred(&mut self) -> ::core::option::Option<{wrpc_transport}::DeferredFn<{wrpc_transport}::Incoming>> {{"
+        fn take_deferred(&mut self) -> ::core::option::Option<{wrpc_transport}::DeferredFn<{wrpc_transport}::BufferedIncoming>> {{"
             );
             if !fields.is_empty() {
                 for Field { name, .. } in fields {
@@ -2080,7 +2080,7 @@ mod {mod_name} {{
     pub enum Decoder
     {{
         Payload(::core::option::Option<PayloadDecoder>),
-        Deferred(::core::option::Option<{wrpc_transport}::DeferredFn<{wrpc_transport}::Incoming>>)
+        Deferred(::core::option::Option<{wrpc_transport}::DeferredFn<{wrpc_transport}::BufferedIncoming>>)
     }}
 
     #[automatically_derived]
@@ -2092,9 +2092,9 @@ mod {mod_name} {{
     }}
 
     #[automatically_derived]
-    impl {wrpc_transport}::Deferred<{wrpc_transport}::Incoming> for Decoder
+    impl {wrpc_transport}::Deferred<{wrpc_transport}::BufferedIncoming> for Decoder
     {{
-        fn take_deferred(&mut self) -> ::core::option::Option<{wrpc_transport}::DeferredFn<{wrpc_transport}::Incoming>> {{
+        fn take_deferred(&mut self) -> ::core::option::Option<{wrpc_transport}::DeferredFn<{wrpc_transport}::BufferedIncoming>> {{
             match self {{
                 Self::Payload(None) => None,"#
                 );
@@ -2194,7 +2194,7 @@ mod {mod_name} {{
                             let Some(payload) = dec.decode(src)? else {{
                                 return Ok(None)
                             }};
-                            *self = Self::Deferred({wrpc_transport}::Deferred::<{wrpc_transport}::Incoming>::take_deferred(dec));
+                            *self = Self::Deferred({wrpc_transport}::Deferred::<{wrpc_transport}::BufferedIncoming>::take_deferred(dec));
                             Ok(Some(super::{name}::{case}(payload)))
                         }},"
                         );

--- a/crates/wit-bindgen-rust/tests/codegen.rs
+++ b/crates/wit-bindgen-rust/tests/codegen.rs
@@ -189,11 +189,11 @@ mod newtyped_list {
 
     macro_rules! impl_codec {
         ($t:ty) => {
-            impl<W> Encode<W> for $t {
+            impl Encode for $t {
                 type Encoder = Codec<Self>;
             }
 
-            impl<R> Decode<R> for $t {
+            impl Decode for $t {
                 type Decoder = Codec<Self>;
                 type ListDecoder = Codec<Vec<Self>>;
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,4 +22,4 @@ pub mod runtime {
     pub use wrpc_wasmtime as wasmtime;
 }
 
-pub use transport::{Index, Invoke, Serve};
+pub use transport::{Invoke, Serve};


### PR DESCRIPTION
wRPC multiplexes the async params/results of an invocation (streams, futures) as sub-streams keyed by a structural `path`. That multiplexing was abstracted behind the public `wrpc_transport::Index<T>` trait so a transport could, in principle, multiplex natively instead of using the framing layer. In practice every in-tree transport (TCP, Unix, QUIC, WebTransport, WebSockets) already funnels a single bidirectional byte stream through `frame::Conn`, so `Index` was pure indirection that complicated the public API (see #1350).

Make the framing layer the one and only multiplexing mechanism:

- Remove the public `Index` trait. `frame::Outgoing`/`frame::Incoming` and the buffered `Incoming` now expose an inherent `index` method.
- Drop the `Outgoing`/`Incoming` associated types from `Invoke`/`Serve`; both now yield the concrete framed `frame::Outgoing`/`frame::Incoming`, and `value.rs` is specialized onto those types instead of being generic over an `Index`-bounded stream parameter.
- A transport now only has to provide a single `AsyncWrite`/`AsyncRead` byte stream; the framing layer supplies the multiplexing.
- Update the wasmtime bridge, `wrpc-pack`, `wrpc-wave`, the Rust bindgen templates and the `wrpc` facade accordingly, and document framing as mandatory in SPEC.md.

This is a backwards-incompatible change to the `wrpc-transport` public API. The Go bindings and wire format are unchanged.

Assisted-by: anthropic:claude-opus-4-8