### PR TITLE
refactor: remove internal Captures workaround trait

### DIFF
--- a/crates/transport/src/lib.rs
+++ b/crates/transport/src/lib.rs
@@ -40,15 +40,6 @@ use bytes::BytesMut;
 use tokio::io::{AsyncRead, ReadBuf};
 use tracing::trace;
 
-/// Internal workaround trait
-///
-/// This is an internal trait used as a workaround for
-/// https://github.com/rust-lang/rust/issues/63033
-#[doc(hidden)]
-pub trait Captures<'a> {}
-
-impl<T: ?Sized> Captures<'_> for T {}
-
 /// Buffered incoming stream used for decoding values
 ///
 /// This wraps the multiplexed framed [`frame::Incoming`] stream with a read buffer used to

--- a/crates/transport/src/serve.rs
+++ b/crates/transport/src/serve.rs
@@ -156,8 +156,6 @@ mod tests {
     use bytes::Bytes;
     use futures::{StreamExt as _, TryStreamExt as _, stream};
 
-    use crate::Captures;
-
     use super::*;
 
     async fn call_serve<T: Serve>(s: &T) -> anyhow::Result<Vec<(T::Context, Outgoing, Incoming)>> {
@@ -198,7 +196,7 @@ mod tests {
         s: &T,
     ) -> impl Future<
         Output = anyhow::Result<Pin<Box<dyn Stream<Item = anyhow::Result<T::Context>> + 'static>>>,
-    > + Captures<'_> {
+    > {
         let fut = s.serve(
             "foo",
             "bar",
@@ -215,7 +213,7 @@ mod tests {
         s: &T,
     ) -> impl Future<
         Output = anyhow::Result<Pin<Box<dyn Stream<Item = anyhow::Result<T::Context>> + 'static>>>,
-    > + crate::Captures<'_> {
+    > {
         let fut = s.serve_values::<(Bytes,), (Bytes,)>(
             "foo",
             "bar",

--- a/crates/wit-bindgen-rust/src/interface.rs
+++ b/crates/wit-bindgen-rust/src/interface.rs
@@ -143,9 +143,9 @@ impl InterfaceGenerator<'_> {
             self.src,
             r#"
 #[allow(clippy::manual_async_fn)]
-pub fn serve_interface<'a, T: {wrpc_transport}::Serve>(
+pub fn serve_interface<'a, T: {wrpc_transport}::Serve, H: Handler<T::Context> + {resource_traits} ::core::marker::Send + ::core::marker::Sync + ::core::clone::Clone + 'static>(
     wrpc: &'a T,
-    handler: impl Handler<T::Context> + {resource_traits} ::core::marker::Send + ::core::marker::Sync + ::core::clone::Clone + 'static,
+    handler: H,
 ) -> impl ::core::future::Future<
         Output = {anyhow}::Result<
             [
@@ -171,7 +171,7 @@ pub fn serve_interface<'a, T: {wrpc_transport}::Serve>(
                 {n}
             ] 
         >
-    > + ::core::marker::Send + {wrpc_transport}::Captures<'a> {{
+    > + ::core::marker::Send + use<'a, T, H> {{
     async move {{
         let ("#,
             resource_traits = trait_names.join(""),
@@ -602,8 +602,7 @@ pub fn serve_interface<'a, T: {wrpc_transport}::Serve>(
                 if async_params || !paths.is_empty() {
                     uwrite!(
                         self.src,
-                        ", ::core::option::Option<impl ::core::future::Future<Output = {anyhow}::Result<()>> + ::core::marker::Send + 'static + {wrpc_transport}::Captures<'a>>)",
-                        wrpc_transport = self.r#gen.wrpc_transport_path(),
+                        ", ::core::option::Option<impl ::core::future::Future<Output = {anyhow}::Result<()>> + ::core::marker::Send + 'static + use<'a, C__>>)",
                     );
                 }
                 uwrite!(self.src, ">> + Send + 'a");
@@ -620,8 +619,7 @@ pub fn serve_interface<'a, T: {wrpc_transport}::Serve>(
                 if async_params || !paths.is_empty() {
                     uwrite!(
                         self.src,
-                        "::core::option::Option<impl ::core::future::Future<Output = {anyhow}::Result<()>> + ::core::marker::Send + 'static + {wrpc_transport}::Captures<'a>>",
-                        wrpc_transport = self.r#gen.wrpc_transport_path(),
+                        "::core::option::Option<impl ::core::future::Future<Output = {anyhow}::Result<()>> + ::core::marker::Send + 'static + use<'a, C__>>",
                     );
                 }
                 uwrite!(self.src, ")>> + Send + 'a");

--- a/crates/wit-bindgen-rust/src/lib.rs
+++ b/crates/wit-bindgen-rust/src/lib.rs
@@ -428,9 +428,9 @@ with: {{\n\t{with_name:?}: generate\n}}
             self.src,
             r#"
 #[allow(clippy::manual_async_fn)]
-pub fn serve<'a, T: {wrpc_transport}::Serve>(
+pub fn serve<'a, T: {wrpc_transport}::Serve, H: {bound} + ::core::marker::Send + ::core::marker::Sync + ::core::clone::Clone + 'static>(
     wrpc: &'a T,
-    handler: impl {bound} + ::core::marker::Send + ::core::marker::Sync + ::core::clone::Clone + 'static,
+    handler: H,
 ) -> impl ::core::future::Future<
         Output = {anyhow}::Result<
             ::std::vec::Vec<
@@ -455,7 +455,7 @@ pub fn serve<'a, T: {wrpc_transport}::Serve>(
                 )
             >
         >
-    > + ::core::marker::Send + {wrpc_transport}::Captures<'a> {{
+    > + ::core::marker::Send + use<'a, T, H> {{
     async move {{
         let interfaces = {tokio}::try_join!("#
         );


### PR DESCRIPTION
`wrpc-transport` carried a `#[doc(hidden)] Captures<'a>` marker trait as a workaround for rust-lang/rust#63033, used to force returned `impl Future`s to capture an otherwise-unused lifetime. Precise capturing (`use<..>`, stable since Rust 1.82) makes it unnecessary.

Drop the trait and its uses:
- transport: remove the trait/impl and the `serve` test bounds (edition 2024 captures the elided lifetime by default).
- rust bindgen: replace `+ Captures<'a>` on generated `serve`/`serve_interface` futures with `+ use<'a, T, H>`, turning the argument-position `impl Handler` into a named generic so it can be named in the `use<..>` bound; the nested deferred futures now use `+ use<'a, C__>`.

Generated bindings continue to compile under both edition 2021 and 2024.

Assisted-by: claude:claude-opus-4-8