### PR TITLE
fix(bindgen): use empty instance for world-root functions

### DIFF
--- a/crates/wit-bindgen-go/src/interface.rs
+++ b/crates/wit-bindgen-go/src/interface.rs
@@ -7,7 +7,7 @@ use heck::ToUpperCamelCase;
 use wit_bindgen_core::wit_parser::{
     Case, Docs, Enum, EnumCase, Field, Flag, Flags, Function, FunctionKind, Handle, Int,
     InterfaceId, Param, Record, Resolve, Result_, Tuple, Type, TypeDefKind, TypeId, TypeOwner,
-    Variant, World, WorldKey,
+    Variant, WorldKey,
 };
 use wit_bindgen_core::{Source, TypeInfo, uwrite, uwriteln};
 use wrpc_introspect::{async_paths_ty, is_list_of, is_tuple, is_ty, rpc_func_name};
@@ -2542,19 +2542,15 @@ func ServeInterface(s {wrpc}.Server, h Handler) (stop func() error, err error) {
                     name
                 }
             }
-            Identifier::World(world) => {
-                let World {
-                    ref name, package, ..
-                } = self.resolve.worlds[world];
-                if let Some(package) = package {
-                    self.resolve.id_of_name(package, name)
-                } else {
-                    name.to_string()
-                }
-            }
+            Identifier::World => String::new(),
         };
         for (i, func) in funcs_to_export.iter().enumerate() {
             let name = rpc_func_name(func);
+            let fqn = if instance.is_empty() {
+                name.to_string()
+            } else {
+                format!("{instance}.{name}")
+            };
 
             let bytes = self.deps.bytes();
             let context = self.deps.context();
@@ -2595,7 +2591,7 @@ func ServeInterface(s {wrpc}.Server, h Handler) (stop func() error, err error) {
             uwriteln!(
                 self.src,
                 r#"
-        {slog}.DebugContext(ctx, "calling `{instance}.{name}` handler")"#,
+        {slog}.DebugContext(ctx, "calling `{fqn}` handler")"#,
             );
             let results: Box<[Type]> = func
                 .result
@@ -2652,7 +2648,7 @@ func ServeInterface(s {wrpc}.Server, h Handler) (stop func() error, err error) {
             uwrite!(
                 self.src,
                 r#"
-        {slog}.DebugContext(ctx, "transmitting `{instance}.{name}` result")
+        {slog}.DebugContext(ctx, "transmitting `{fqn}` result")
         _, err = w.Write(buf.Bytes())
         if err != nil {{
             {slog}.WarnContext(ctx, "failed to write result", "instance", "{instance}", "name", "{name}", "err", err)
@@ -2725,7 +2721,7 @@ func ServeInterface(s {wrpc}.Server, h Handler) (stop func() error, err error) {
                 self.src,
                 r#")
              if err != nil {{
-                 return nil, {fmt}.Errorf("failed to serve `{instance}.{name}`: %w", err)
+                 return nil, {fmt}.Errorf("failed to serve `{fqn}`: %w", err)
              }}
              stops = append(stops, stop{i})"#,
             );

--- a/crates/wit-bindgen-go/src/lib.rs
+++ b/crates/wit-bindgen-go/src/lib.rs
@@ -9,9 +9,7 @@ use std::mem;
 use std::process::{Command, Stdio};
 use wit_bindgen_core::{
     Files, InterfaceGenerator as _, Source, Types, WorldGenerator, uwrite, uwriteln,
-    wit_parser::{
-        Function, InterfaceId, PackageId, Resolve, TypeId, World, WorldId, WorldItem, WorldKey,
-    },
+    wit_parser::{Function, InterfaceId, PackageId, Resolve, TypeId, WorldId, WorldItem, WorldKey},
 };
 
 mod interface;
@@ -537,26 +535,14 @@ impl WorldGenerator for GoWrpc {
     fn import_funcs(
         &mut self,
         resolve: &Resolve,
-        world: WorldId,
+        _world: WorldId,
         funcs: &[(&str, &Function)],
         _files: &mut Files,
     ) {
         self.import_funcs_called = true;
 
-        let mut r#gen = self.interface(Identifier::World(world), resolve, true);
-        let World {
-            ref name, package, ..
-        } = resolve.worlds[world];
-        let instance = if let Some(package) = package {
-            resolve.id_of_name(package, name)
-        } else {
-            name.to_string()
-        };
-        r#gen.generate_imports(
-            Identifier::World(world),
-            &instance,
-            funcs.iter().map(|(_, func)| *func),
-        );
+        let mut r#gen = self.interface(Identifier::World, resolve, true);
+        r#gen.generate_imports(Identifier::World, "", funcs.iter().map(|(_, func)| *func));
 
         let src = r#gen.finish();
         for (k, v) in r#gen.deps.map {
@@ -600,12 +586,12 @@ impl WorldGenerator for GoWrpc {
     fn export_funcs(
         &mut self,
         resolve: &Resolve,
-        world: WorldId,
+        _world: WorldId,
         funcs: &[(&str, &Function)],
         _files: &mut Files,
     ) -> Result<()> {
-        let mut r#gen = self.interface(Identifier::World(world), resolve, false);
-        let exports = r#gen.generate_exports(Identifier::World(world), funcs.iter().map(|f| f.1));
+        let mut r#gen = self.interface(Identifier::World, resolve, false);
+        let exports = r#gen.generate_exports(Identifier::World, funcs.iter().map(|f| f.1));
         let src = r#gen.finish();
         for (k, v) in r#gen.deps.map {
             self.deps.import(k, v);
@@ -620,11 +606,11 @@ impl WorldGenerator for GoWrpc {
     fn import_types(
         &mut self,
         resolve: &Resolve,
-        world: WorldId,
+        _world: WorldId,
         types: &[(&str, TypeId)],
         _files: &mut Files,
     ) {
-        let mut r#gen = self.interface(Identifier::World(world), resolve, true);
+        let mut r#gen = self.interface(Identifier::World, resolve, true);
         for (name, ty) in types {
             r#gen.define_type(name, *ty);
         }
@@ -699,7 +685,7 @@ fn compute_module_path(name: &WorldKey, resolve: &Resolve, is_export: bool) -> V
 }
 
 enum Identifier<'a> {
-    World(WorldId),
+    World,
     Interface(InterfaceId, &'a WorldKey),
 }
 

--- a/crates/wit-bindgen-rust/src/interface.rs
+++ b/crates/wit-bindgen-rust/src/interface.rs
@@ -8,8 +8,7 @@ use std::fmt::Write as _;
 use std::mem;
 use wit_bindgen_core::wit_parser::{
     Case, Docs, Enum, Field, Flags, Function, FunctionKind, Handle, Int, InterfaceId, Param,
-    Record, Resolve, Result_, Tuple, Type, TypeDefKind, TypeId, TypeOwner, Variant, World,
-    WorldKey,
+    Record, Resolve, Result_, Tuple, Type, TypeDefKind, TypeId, TypeOwner, Variant, WorldKey,
 };
 use wit_bindgen_core::{Source, TypeInfo, dealias, uwrite, uwriteln};
 use wrpc_introspect::{async_paths_ty, async_paths_tyid, is_ty, rpc_func_name};
@@ -214,18 +213,14 @@ pub fn serve_interface<'a, T: {wrpc_transport}::Serve, H: Handler<T::Context> + 
                     name
                 }
             }
-            Identifier::World(world) => {
-                let World {
-                    ref name, package, ..
-                } = self.resolve.worlds[world];
-                if let Some(package) = package {
-                    self.resolve.id_of_name(package, name)
-                } else {
-                    name.to_string()
-                }
-            }
+            Identifier::World => String::new(),
         };
         for func in &funcs_to_export {
+            let fqn = if instance.is_empty() {
+                func.name.to_string()
+            } else {
+                format!("{instance}.{}", func.name)
+            };
             let paths = func.params.iter().enumerate().fold(
                 BTreeSet::default(),
                 |mut paths, (i, param)| {
@@ -283,9 +278,8 @@ pub fn serve_interface<'a, T: {wrpc_transport}::Serve, H: Handler<T::Context> + 
                 r#")
                 )
                 .await,
-                "failed to serve `{instance}.{}`")
+                "failed to serve `{fqn}`")
             }},"#,
-                func.name,
             );
         }
         self.push_str(")?;\n");
@@ -297,6 +291,11 @@ pub fn serve_interface<'a, T: {wrpc_transport}::Serve, H: Handler<T::Context> + 
         );
         for func in &funcs_to_export {
             let name = to_rust_ident(&func.name);
+            let fqn = if instance.is_empty() {
+                func.name.to_string()
+            } else {
+                format!("{instance}.{}", func.name)
+            };
             uwrite!(
                 self.src,
                 r#"
@@ -381,11 +380,11 @@ pub fn serve_interface<'a, T: {wrpc_transport}::Serve, H: Handler<T::Context> + 
                                                     {tracing}::trace!(instance = "{instance}", func = "{wit_name}", "receiving async invocation parameters");
                                                     let rx = {anyhow}::Context::context(
                                                         rx.await,
-                                                        "`{instance}.{wit_name}` async parameter receipt task failed",
+                                                        "`{fqn}` async parameter receipt task failed",
                                                     )?;
                                                     {anyhow}::Context::context(
                                                         rx,
-                                                        "failed to receive `{instance}.{wit_name}` async parameters",
+                                                        "failed to receive `{fqn}` async parameters",
                                                     )
                                                 }} else {{
                                                     {anyhow}::Ok(())
@@ -395,7 +394,7 @@ pub fn serve_interface<'a, T: {wrpc_transport}::Serve, H: Handler<T::Context> + 
                                                 if let Some(rx) = rx {{
                                                     rx.abort();
                                                 }}
-                                                {anyhow}::bail!(err.context("failed to transmit `{instance}.{wit_name}` invocation results"))
+                                                {anyhow}::bail!(err.context("failed to transmit `{fqn}` invocation results"))
                                             }},
                                         }}
                                     }},
@@ -403,7 +402,7 @@ pub fn serve_interface<'a, T: {wrpc_transport}::Serve, H: Handler<T::Context> + 
                                         if let Some(rx) = rx {{
                                             rx.abort();
                                         }}
-                                        {anyhow}::bail!(err.context("failed to serve `{instance}.{wit_name}` invocation"))
+                                        {anyhow}::bail!(err.context("failed to serve `{fqn}` invocation"))
                                     }},
                                 }}
                             }})
@@ -526,6 +525,12 @@ pub fn serve_interface<'a, T: {wrpc_transport}::Serve, H: Handler<T::Context> + 
         if self.r#gen.skip.contains(&func.name) {
             return;
         }
+
+        let fqn = if instance.is_empty() {
+            func.name.to_string()
+        } else {
+            format!("{instance}.{}", func.name)
+        };
 
         let mut sig = FnSig::default();
         match func.kind {
@@ -661,8 +666,7 @@ pub fn serve_interface<'a, T: {wrpc_transport}::Serve, H: Handler<T::Context> + 
             uwriteln!(
                 self.src,
                 r#"
-                    "failed to invoke `{instance}.{}`")?;"#,
-                func.name,
+                    "failed to invoke `{fqn}`")?;"#,
             );
             if func.result.iter().len() == 1 {
                 self.push_str("let (wrpc__,) = wrpc__;\n");
@@ -698,8 +702,7 @@ pub fn serve_interface<'a, T: {wrpc_transport}::Serve, H: Handler<T::Context> + 
             uwriteln!(
                 self.src,
                 r#"
-                    "failed to invoke `{instance}.{}`")?;"#,
-                func.name,
+                    "failed to invoke `{fqn}`")?;"#,
             );
             if func.result.iter().len() == 1 {
                 self.push_str("let (wrpc__,) = wrpc__;\n");

--- a/crates/wit-bindgen-rust/src/lib.rs
+++ b/crates/wit-bindgen-rust/src/lib.rs
@@ -5,8 +5,8 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt::{self, Write as _};
 use std::mem;
 use wit_bindgen_core::wit_parser::{
-    Flags, FlagsRepr, Function, Int, InterfaceId, Resolve, SizeAlign, TypeId, TypeOwner, World,
-    WorldId, WorldItem, WorldKey,
+    Flags, FlagsRepr, Function, Int, InterfaceId, Resolve, SizeAlign, TypeId, TypeOwner, WorldId,
+    WorldItem, WorldKey,
 };
 use wit_bindgen_core::{
     Files, InterfaceGenerator as _, Source, Types, WorldGenerator, dealias, name_package_module,
@@ -596,22 +596,14 @@ impl WorldGenerator for RustWrpc {
     fn import_funcs(
         &mut self,
         resolve: &Resolve,
-        world: WorldId,
+        _world: WorldId,
         funcs: &[(&str, &Function)],
         _files: &mut Files,
     ) {
         self.import_funcs_called = true;
 
-        let mut r#gen = self.interface(Identifier::World(world), resolve, true);
-        let World {
-            ref name, package, ..
-        } = resolve.worlds[world];
-        let instance = if let Some(package) = package {
-            resolve.id_of_name(package, name)
-        } else {
-            name.to_string()
-        };
-        r#gen.generate_imports(&instance, funcs.iter().map(|(_, func)| *func));
+        let mut r#gen = self.interface(Identifier::World, resolve, true);
+        r#gen.generate_imports("", funcs.iter().map(|(_, func)| *func));
 
         let src = r#gen.finish();
         self.src.push_str(&src);
@@ -660,12 +652,12 @@ impl WorldGenerator for RustWrpc {
     fn export_funcs(
         &mut self,
         resolve: &Resolve,
-        world: WorldId,
+        _world: WorldId,
         funcs: &[(&str, &Function)],
         _files: &mut Files,
     ) -> Result<()> {
-        let mut r#gen = self.interface(Identifier::World(world), resolve, false);
-        let exports = r#gen.generate_exports(Identifier::World(world), funcs.iter().map(|f| f.1));
+        let mut r#gen = self.interface(Identifier::World, resolve, false);
+        let exports = r#gen.generate_exports(Identifier::World, funcs.iter().map(|f| f.1));
         let src = r#gen.finish();
         self.src.push_str(&src);
         if exports {
@@ -677,7 +669,7 @@ impl WorldGenerator for RustWrpc {
     fn import_types(
         &mut self,
         resolve: &Resolve,
-        world: WorldId,
+        _world: WorldId,
         types: &[(&str, TypeId)],
         _files: &mut Files,
     ) {
@@ -694,7 +686,7 @@ impl WorldGenerator for RustWrpc {
             }
             self.generated_types.insert(full_name);
         }
-        let mut r#gen = self.interface(Identifier::World(world), resolve, true);
+        let mut r#gen = self.interface(Identifier::World, resolve, true);
         for (name, ty) in to_define {
             r#gen.define_type(name, *ty);
         }
@@ -778,7 +770,7 @@ fn compute_module_path(name: &WorldKey, resolve: &Resolve, is_export: bool) -> V
 }
 
 enum Identifier<'a> {
-    World(WorldId),
+    World,
     Interface(InterfaceId, &'a WorldKey),
 }
 

--- a/tests/rust.rs
+++ b/tests/rust.rs
@@ -679,6 +679,89 @@ where
 }
 
 #[instrument(skip_all, ret)]
+async fn assert_bindgen_root<IC, SC, I, S>(cx: IC, clt: Arc<I>, srv: Arc<S>) -> anyhow::Result<()>
+where
+    IC: Clone + Send + Sync,
+    SC: Send + Sync,
+    I: wrpc::Invoke<Context = IC> + 'static,
+    S: wrpc::Serve<Context = SC> + Send + 'static,
+{
+    let span = Span::current();
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+    let shutdown_rx = async move { shutdown_rx.await.expect("shutdown sender dropped") }.shared();
+    try_join!(
+        async {
+            mod bindings {
+                wit_bindgen_wrpc::generate!({
+                    world: "root-server",
+                    path: "tests/wit",
+                });
+            }
+
+            #[derive(Clone, Default)]
+            struct Component {}
+
+            impl<C: Send + Sync> bindings::Handler<C> for Component {
+                async fn ping(&self, _cx: C) -> anyhow::Result<String> {
+                    Ok("pong".to_string())
+                }
+            }
+
+            let srv = Arc::clone(&srv);
+            let shutdown_rx = shutdown_rx.clone();
+            tokio::spawn(async move {
+                let invocations = bindings::serve(srv.as_ref(), Component::default())
+                    .await
+                    .context("failed to serve `root-server` world exports")?;
+                let mut invocations = stream::select_all(invocations.into_iter().map(
+                    |(instance, name, invocations)| {
+                        assert_eq!(instance, "");
+                        invocations.map(move |res| (instance, name, res))
+                    },
+                ));
+                loop {
+                    let shutdown_rx = shutdown_rx.clone();
+                    select! {
+                        Some((instance, name, invocation)) = invocations.next() => {
+                            info!(instance, name, "serving invocation");
+                            invocation
+                                .unwrap_or_else(|err| panic!("failed to accept `{instance}#{name}` invocation: {err:?}"))
+                                .await
+                                .expect("failed to serve invocation");
+                        }
+                        () = shutdown_rx => {
+                            info!("shutting down");
+                            return anyhow::Ok(())
+                        }
+                    }
+                }
+            }.instrument(span.clone()))
+            .await?
+        },
+        async {
+            mod bindings {
+                wit_bindgen_wrpc::generate!({
+                    world: "root-client",
+                    path: "tests/wit",
+                });
+            }
+
+            // TODO: Remove the need for this
+            sleep(Duration::from_secs(1)).await;
+
+            let v = bindings::ping(clt.as_ref(), cx.clone())
+                .await
+                .context("failed to call `ping`")?;
+            assert_eq!(v, "pong");
+
+            shutdown_tx.send(()).expect("failed to send shutdown");
+            Ok(())
+        },
+    )?;
+    Ok(())
+}
+
+#[instrument(skip_all, ret)]
 async fn assert_dynamic<IC, SC, I, S>(cx: IC, clt: Arc<I>, srv: Arc<S>) -> anyhow::Result<()>
 where
     IC: Clone + Send + Sync + 'static,
@@ -1373,6 +1456,44 @@ async fn rust_bindgen_tcp_sync() -> anyhow::Result<()> {
     let mut fut = pin!(
         async {
             assert_bindgen_sync(
+                (),
+                Arc::new(wrpc_transport::frame::tcp::Client::from(addr)),
+                Arc::clone(&srv),
+            )
+            .await
+        }
+        .instrument(span.clone())
+    );
+    loop {
+        let accept = async {
+            let (stream, addr) = lis.accept().await.expect("failed to accept connection");
+            assert!(addr.ip().is_loopback());
+            let (rx, tx) = stream.into_split();
+            srv.accept((), tx, rx)
+                .await
+                .expect("failed to accept connection");
+        }
+        .instrument(span.clone());
+        select! {
+            res = &mut fut => return res,
+            () = accept => continue,
+        }
+    }
+}
+
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
+#[instrument(ret)]
+async fn rust_bindgen_tcp_root() -> anyhow::Result<()> {
+    let lis = tokio::net::TcpListener::bind((Ipv6Addr::LOCALHOST, 0))
+        .await
+        .context("failed to start TCP listener")?;
+    let addr = lis.local_addr().context("failed to get server address")?;
+
+    let srv = Arc::new(wrpc_transport::frame::Server::default());
+    let span = Span::current();
+    let mut fut = pin!(
+        async {
+            assert_bindgen_root(
                 (),
                 Arc::new(wrpc_transport::frame::tcp::Client::from(addr)),
                 Arc::clone(&srv),

--- a/tests/wit/test.wit
+++ b/tests/wit/test.wit
@@ -102,6 +102,14 @@ world resources-client {
     }
 }
 
+world root-server {
+    export ping: func() -> string;
+}
+
+world root-client {
+    import ping: func() -> string;
+}
+
 interface get-types {
     flags feature-flags {
         show-a,


### PR DESCRIPTION
`wit-bindgen-wrpc` addressed functions defined at the root of a world by the world id (e.g. `my-pkg:foo/my-world`), baking the world name into the wire identity. This diverged from `wrpc-wasmtime`, which serves component root exports at the empty instance `""`, so natively-generated bindings could never interoperate with components hosted over wRPC. It also meant that differently-named client/server worlds with identical root functions could not call each other, even though they are structurally interchangeable component types.

Generate invocations and serving of world-root functions at the empty instance `""` in both the Rust and Go binding generators, matching `wrpc-wasmtime` and upstream `wit-bindgen` semantics, where world names never reach the binary interface. Render diagnostics for root functions as the bare function name instead of a `.`-prefixed path.

Assisted-by: claude:claude-fable-5